### PR TITLE
Updated filename_masks for Pioneer profiler moorings

### DIFF
--- a/CP02PMCI/CP02PMCI_R00006_ingest.csv
+++ b/CP02PMCI/CP02PMCI_R00006_ingest.csv
@@ -1,11 +1,11 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/CWFP*/0*00/A*.DA?,CP02PMCI-WFP01-01-VEL3DK000,recovered_wfp,Not recovered yet
-#Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/CWFP*/0*00/C*.DA?,CP02PMCI-WFP01-03-CTDPFK000,recovered_wfp,Not recovered yet
-#Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/CWFP*/0*00/C*.DA?,CP02PMCI-WFP01-02-DOFSTK000,recovered_wfp,Not recovered yet
-#Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/CWFP*/0*00/E*.DA?,CP02PMCI-WFP01-00-WFPENG000,recovered_wfp,Not recovered yet
-#Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/CWFP*/0*00/E*.DA?,CP02PMCI-WFP01-04-FLORTK000,recovered_wfp,Not recovered yet
-#Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/CWFP*/0*00/E*.DA?,CP02PMCI-WFP01-05-PARADK000,recovered_wfp,Not recovered yet
-#Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/ADCP*/*RDI_000.000,CP02PMCI-RII01-02-ADCPTG010,recovered_inst,Not recovered yet
-#Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/imm/adcpt/adcpt*.DAT,CP02PMCI-RII01-02-ADCPTG010,recovered_host,Not recovered yet
-#Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/MOPAK*/*_*.3dmgx3.log,CP02PMCI-SBS01-01-MOPAK0000,recovered_host,Not recovered yet
-#Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/dcl00/irid2shore/stc_status.*_*.txt,CP02PMCI-SBS01-00-STCENG000,recovered_host,Not recovered yet
+uframe_route,filename_mask,reference_designator,data_source
+Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/instruments/CWFP*/0*00/A*.DA?,CP02PMCI-WFP01-01-VEL3DK000,recovered_wfp
+Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/instruments/CWFP*/0*00/C*.DA?,CP02PMCI-WFP01-03-CTDPFK000,recovered_wfp
+Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/instruments/CWFP*/0*00/C*.DA?,CP02PMCI-WFP01-02-DOFSTK000,recovered_wfp
+Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/instruments/CWFP*/0*00/E*.DA?,CP02PMCI-WFP01-00-WFPENG000,recovered_wfp
+Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/instruments/CWFP*/0*00/E*.DA?,CP02PMCI-WFP01-04-FLORTK000,recovered_wfp
+Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/instruments/CWFP*/0*00/E*.DA?,CP02PMCI-WFP01-05-PARADK000,recovered_wfp
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/instruments/ADCP*/*RDI_000.000,CP02PMCI-RII01-02-ADCPTG010,recovered_inst
+Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/stc1/imm/adcpt/adcpt*.DAT,CP02PMCI-RII01-02-ADCPTG010,recovered_host
+Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/stc1/3dmgx3/*.3dmgx3.log,CP02PMCI-SBS01-01-MOPAK0000,recovered_host
+Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMCI/R00006/cg_data/stc1/irid2shore/stc_status*.txt,CP02PMCI-SBS01-00-STCENG000,recovered_host

--- a/CP02PMCO/CP02PMCO_R00006_ingest.csv
+++ b/CP02PMCO/CP02PMCO_R00006_ingest.csv
@@ -1,11 +1,11 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/CWFP_sn13103-05/*/A*.DA?,CP02PMCO-WFP01-01-VEL3DK000,recovered_wfp,No data on server
-#Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/CWFP_sn13103-05/*/C*.DA?,CP02PMCO-WFP01-03-CTDPFK000,recovered_wfp,No data on server
-#Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/CWFP_sn13103-05/*/C*.DA?,CP02PMCO-WFP01-02-DOFSTK000,recovered_wfp,No data on server
-#Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/CWFP_sn13103-05/*/E*.DA?,CP02PMCO-WFP01-00-WFPENG000,recovered_wfp,No data on server
-#Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/CWFP_sn13103-05/*/E*.DA?,CP02PMCO-WFP01-04-FLORTK000,recovered_wfp,No data on server
-#Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/CWFP_sn13103-05/*/E*.DA?,CP02PMCO-WFP01-05-PARADK000,recovered_wfp,No data on server
-#Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/ADCP_sn18660/_RDI_000.000,CP02PMCO-RII01-02-ADCPTG010,recovered_inst,No data on server
-#Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/imm/adcpt/adcpt*.DAT,CP02PMCO-RII01-02-ADCPTG010,recovered_host,No data on server
-#Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/MOPAK*/*_*.3dmgx3.log,CP02PMCO-SBS01-01-MOPAK0000,recovered_host,No data on server
-#Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/dcl00/irid2shore/stc_status.*_*.txt,CP02PMCO-SBS01-00-STCENG000,recovered_host,No data on server
+uframe_route,filename_mask,reference_designator,data_source
+Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/instruments/CWFP_sn13103-05/0*/A*.DA?,CP02PMCO-WFP01-01-VEL3DK000,recovered_wfp
+Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/instruments/CWFP_sn13103-05/0*/C*.DA?,CP02PMCO-WFP01-03-CTDPFK000,recovered_wfp
+Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/instruments/CWFP_sn13103-05/0*/C*.DA?,CP02PMCO-WFP01-02-DOFSTK000,recovered_wfp
+Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/instruments/CWFP_sn13103-05/0*/E*.DA?,CP02PMCO-WFP01-00-WFPENG000,recovered_wfp
+Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/instruments/CWFP_sn13103-05/0*/E*.DA?,CP02PMCO-WFP01-04-FLORTK000,recovered_wfp
+Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/instruments/CWFP_sn13103-05/0*/E*.DA?,CP02PMCO-WFP01-05-PARADK000,recovered_wfp
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/instruments/ADCP_sn18660/_RDI_000.000,CP02PMCO-RII01-02-ADCPTG010,recovered_inst
+Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/stc1/imm/adcpt/adcpt*.DAT,CP02PMCO-RII01-02-ADCPTG010,recovered_host
+Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/stc1/3dmgx3/*.3dmgx3.log,CP02PMCO-SBS01-01-MOPAK0000,recovered_host
+Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMCO/R00006/cg_data/stc1/irid2shore/stc_status*.txt,CP02PMCO-SBS01-00-STCENG000,recovered_host

--- a/CP02PMUI/CP02PMUI_R00007_ingest.csv
+++ b/CP02PMUI/CP02PMUI_R00007_ingest.csv
@@ -1,11 +1,11 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/CWFP_sn12991-02/*/A*.DA?,CP02PMUI-WFP01-01-VEL3DK000,recovered_wfp,Not recovered yet
-#Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/CWFP_sn12991-02/*/C*.DA?,CP02PMUI-WFP01-03-CTDPFK000,recovered_wfp,Not recovered yet
-#Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/CWFP_sn12991-02/*/C*.DA?,CP02PMUI-WFP01-02-DOFSTK000,recovered_wfp,Not recovered yet
-#Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/CWFP_sn12991-02/*/E*.DA?,CP02PMUI-WFP01-00-WFPENG000,recovered_wfp,Not recovered yet
-#Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/CWFP_sn12991-02/*/E*.DA?,CP02PMUI-WFP01-04-FLORTK000,recovered_wfp,Not recovered yet
-#Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/CWFP_sn12991-02/*/E*.DA?,CP02PMUI-WFP01-05-PARADK000,recovered_wfp,Not recovered yet
-#Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/ADCP_sn20496/*.000,CP02PMUI-RII01-02-ADCPTG010,recovered_inst,Not recovered yet
-#Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/imm/adcpt/adcpt*.DAT,CP02PMUI-RII01-02-ADCPTG010,recovered_host,Not recovered yet
-#Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/MOPAK_sn/*_*.3dmgx3.log,CP02PMUI-SBS01-01-MOPAK0000,recovered_host,Not recovered yet
-#Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/dcl00/irid2shore/stc_status.*_*.txt,CP02PMUI-SBS01-00-STCENG000,recovered_host,Not recovered yet
+uframe_route,filename_mask,reference_designator,data_source
+Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/instruments/CWFP_sn13103-02/0*/A*.DA?,CP02PMUI-WFP01-01-VEL3DK000,recovered_wfp
+Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/instruments/CWFP_sn13103-02/0*/C*.DA?,CP02PMUI-WFP01-03-CTDPFK000,recovered_wfp
+Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/instruments/CWFP_sn13103-02/0*/C*.DA?,CP02PMUI-WFP01-02-DOFSTK000,recovered_wfp
+Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/instruments/CWFP_sn13103-02/0*/E*.DA?,CP02PMUI-WFP01-00-WFPENG000,recovered_wfp
+Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/instruments/CWFP_sn13103-02/0*/E*.DA?,CP02PMUI-WFP01-04-FLORTK000,recovered_wfp
+Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/instruments/CWFP_sn13103-02/0*/E*.DA?,CP02PMUI-WFP01-05-PARADK000,recovered_wfp
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/instruments/ADCP_sn20496/*.000,CP02PMUI-RII01-02-ADCPTG010,recovered_inst
+Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/stc1/imm/adcpt/adcpt*.DAT,CP02PMUI-RII01-02-ADCPTG010,recovered_host
+Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/stc1/3dmgx3/*.3dmgx3.log,CP02PMUI-SBS01-01-MOPAK0000,recovered_host
+Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMUI/R00007/cg_data/stc1/irid2shore/stc_status*.txt,CP02PMUI-SBS01-00-STCENG000,recovered_host

--- a/CP02PMUO/CP02PMUO_R00007_ingest.csv
+++ b/CP02PMUO/CP02PMUO_R00007_ingest.csv
@@ -1,11 +1,11 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/CWFP*/*00/A*.DA?,CP02PMUO-WFP01-01-VEL3DK000,recovered_wfp,not recovered yet
-#Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/CWFP*/*00/C*.DA?,CP02PMUO-WFP01-03-CTDPFK000,recovered_wfp,not recovered yet
-#Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/CWFP*/*00/C*.DA?,CP02PMUO-WFP01-02-DOFSTK000,recovered_wfp,not recovered yet
-#Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/CWFP*/*00/E*.DA?,CP02PMUO-WFP01-00-WFPENG000,recovered_wfp,not recovered yet
-#Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/CWFP*/*00/E*.DA?,CP02PMUO-WFP01-04-FLORTK000,recovered_wfp,not recovered yet
-#Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/CWFP*/*00/E*.DA?,CP02PMUO-WFP01-05-PARADK000,recovered_wfp,not recovered yet
-#Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/ADCP*/*RDI_*.000,CP02PMUO-RII01-02-ADCPSL010,recovered_inst,not recovered yet
-#Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/imm/adcp/adcp*.DAT,CP02PMUO-RII01-02-ADCPSL010,recovered_host,not recovered yet
-#Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/MOPAK*/*.3dmgx3.log,CP02PMUO-SBS01-01-MOPAK0000,recovered_host,not recovered yet
-#Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/dcl00/irid2shore/stc_status.*_*.txt,CP02PMUO-SBS01-00-STCENG000,recovered_host,not recovered yet
+uframe_route,filename_mask,reference_designator,data_source
+Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/instruments/CWFP*/*00/A*.DA?,CP02PMUO-WFP01-01-VEL3DK000,recovered_wfp
+Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/instruments/CWFP*/*00/C*.DA?,CP02PMUO-WFP01-03-CTDPFK000,recovered_wfp
+Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/instruments/CWFP*/*00/C*.DA?,CP02PMUO-WFP01-02-DOFSTK000,recovered_wfp
+Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/instruments/CWFP*/*00/E*.DA?,CP02PMUO-WFP01-00-WFPENG000,recovered_wfp
+Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/instruments/CWFP*/*00/E*.DA?,CP02PMUO-WFP01-04-FLORTK000,recovered_wfp
+Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/instruments/CWFP*/*00/E*.DA?,CP02PMUO-WFP01-05-PARADK000,recovered_wfp
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/instruments/ADCP*/*RDI_*.000,CP02PMUO-RII01-02-ADCPSL010,recovered_inst
+Ingest.adcps-jln-stc_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/stc1/imm/adcp/adcp*.DAT,CP02PMUO-RII01-02-ADCPSL010,recovered_host
+Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/stc1/3dmgx3/*.3dmgx3.log,CP02PMUO-SBS01-01-MOPAK0000,recovered_host
+Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP02PMUO/R00007/cg_data/stc1/irid2shore/stc_status*.txt,CP02PMUO-SBS01-00-STCENG000,recovered_host

--- a/CP04OSPM/CP04OSPM_R00005_ingest.csv
+++ b/CP04OSPM/CP04OSPM_R00005_ingest.csv
@@ -1,9 +1,9 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/CWFP_sn13103-03/0*/A*.DA?,CP04OSPM-WFP01-01-VEL3DK000,recovered_wfp,not recovered yet
-#Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/CWFP_sn13103-03/0*/C*.DA?,CP04OSPM-WFP01-03-CTDPFK000,recovered_wfp,not recovered yet
-#Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/CWFP_sn13103-03/0*/C*.DA?,CP04OSPM-WFP01-02-DOFSTK000,recovered_wfp,not recovered yet
-#Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/CWFP_sn13103-03/0*/E*.DA?,CP04OSPM-WFP01-00-WFPENG000,recovered_wfp,not recovered yet
-#Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/CWFP_sn13103-03/0*/E*.DA?,CP04OSPM-WFP01-04-FLORTK000,recovered_wfp,not recovered yet
-#Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/CWFP_sn13103-03/0*/E*.DA?,CP04OSPM-WFP01-05-PARADK000,recovered_wfp,not recovered yet
-#Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/MOPAK_sn/*_*.3dmgx3.log,CP04OSPM-SBS11-02-MOPAK0000,recovered_host,not recovered yet
-#Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/dcl00/irid2shore/stc_status.*_*.txt,CP04OSPM-SBS01-00-STCENG000,recovered_host,not recovered yet
+uframe_route,filename_mask,reference_designator,data_source
+Ingest.vel3d-k-wfp-stc_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/instruments/CWFP_sn13103-03/0*/A*.DA?,CP04OSPM-WFP01-01-VEL3DK000,recovered_wfp
+Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/instruments/CWFP_sn13103-03/0*/C*.DA?,CP04OSPM-WFP01-03-CTDPFK000,recovered_wfp
+Ingest.dofst-k-wfp_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/instruments/CWFP_sn13103-03/0*/C*.DA?,CP04OSPM-WFP01-02-DOFSTK000,recovered_wfp
+Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/instruments/CWFP_sn13103-03/0*/E*.DA?,CP04OSPM-WFP01-00-WFPENG000,recovered_wfp
+Ingest.flort-kn-stc-imodem_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/instruments/CWFP_sn13103-03/0*/E*.DA?,CP04OSPM-WFP01-04-FLORTK000,recovered_wfp
+Ingest.parad-k-stc-imodem_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/instruments/CWFP_sn13103-03/0*/E*.DA?,CP04OSPM-WFP01-05-PARADK000,recovered_wfp
+Ingest.mopak-o-dcl_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/stc1/3dmgx3/*_*.3dmgx3.log,CP04OSPM-SBS11-02-MOPAK0000,recovered_host
+Ingest.cg-stc-eng-stc_recovered,/omc_data/whoi/OMC/CP04OSPM/R00005/cg_data/stc1/irid2shore/stc_status*.txt,CP04OSPM-SBS01-00-STCENG000,recovered_host


### PR DESCRIPTION
Updated filename_masks for latest recovered deployments of Pioneer
profiler moorings after reorganization of folder structure according to
Redmine ticket # 11674