### PR TITLE
update - added status column

### DIFF
--- a/GA02HYPM/GA02HYPM_D00001_ingest.csv
+++ b/GA02HYPM/GA02HYPM_D00001_ingest.csv
@@ -1,15 +1,15 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399421.dat,GA02HYPM-WFP02-01-FLORDL000,telemetered,
-Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399421.dat,GA02HYPM-WFP02-03-DOSTAL000,telemetered,
-Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wc_wfp_1399421.dat,GA02HYPM-WFP02-04-CTDPFL000,telemetered,
-Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wa_wfp_1399421.dat,GA02HYPM-WFP02-05-VEL3DL000,telemetered,
-Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399422.dat,GA02HYPM-WFP03-01-FLORDL000,telemetered,
-Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399422.dat,GA02HYPM-WFP03-03-DOSTAL000,telemetered,
-Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wc_wfp_1399422.dat,GA02HYPM-WFP03-04-CTDPFL000,telemetered,
-Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wa_wfp_1399422.dat,GA02HYPM-WFP03-05-VEL3DL000,telemetered,
-Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*ctdmo*.dat,GA02HYPM-RIM01-02-CTDMOG039,telemetered,
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/node*p1_*.status_*.dat,GA02HYPM-RIM01-00-SIOENG000,telemetered,
-Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399422.dat,GA02HYPM-WFP03-00-WFPENG000,telemetered,
-Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399421.dat,GA02HYPM-WFP02-00-WFPENG000,telemetered,
-#,,GA02HYPM-MPM01-02-ZPLSGA009,telemetered,Not installed
-#,,GA02HYPM-MPM01-02-ZPLSGA010,telemetered,Not installed
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#,,GA02HYPM-MPM01-02-ZPLSGA009,telemetered,Not Deployed,Not installed
+#,,GA02HYPM-MPM01-02-ZPLSGA010,telemetered,Not Deployed,Not installed
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/node*p1_*.status_*.dat,GA02HYPM-RIM01-00-SIOENG000,telemetered,Available,
+Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*ctdmo*.dat,GA02HYPM-RIM01-02-CTDMOG039,telemetered,Available,
+Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399421.dat,GA02HYPM-WFP02-00-WFPENG000,telemetered,Available,
+Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399421.dat,GA02HYPM-WFP02-01-FLORDL000,telemetered,Available,
+Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399421.dat,GA02HYPM-WFP02-03-DOSTAL000,telemetered,Available,
+Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wc_wfp_1399421.dat,GA02HYPM-WFP02-04-CTDPFL000,telemetered,Available,
+Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wa_wfp_1399421.dat,GA02HYPM-WFP02-05-VEL3DL000,telemetered,Available,
+Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399422.dat,GA02HYPM-WFP03-00-WFPENG000,telemetered,Available,
+Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399422.dat,GA02HYPM-WFP03-01-FLORDL000,telemetered,Available,
+Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.we_wfp_1399422.dat,GA02HYPM-WFP03-03-DOSTAL000,telemetered,Available,
+Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wc_wfp_1399422.dat,GA02HYPM-WFP03-04-CTDPFL000,telemetered,Available,
+Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00001/*.wa_wfp_1399422.dat,GA02HYPM-WFP03-05-VEL3DL000,telemetered,Available,

--- a/GA02HYPM/GA02HYPM_D00002_ingest.csv
+++ b/GA02HYPM/GA02HYPM_D00002_ingest.csv
@@ -1,15 +1,15 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399421.dat,GA02HYPM-WFP02-01-FLORDL000,telemetered,Data not expected - glider not available to send data
-#Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399421.dat,GA02HYPM-WFP02-03-DOSTAL000,telemetered,Data not expected - glider not available to send data
-#Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wc_wfp_1399421.dat,GA02HYPM-WFP02-04-CTDPFL000,telemetered,Data not expected - glider not available to send data
-#Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wa_wfp_1399421.dat,GA02HYPM-WFP02-05-VEL3DL000,telemetered,Data not expected - glider not available to send data
-#Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399422.dat,GA02HYPM-WFP03-01-FLORDL000,telemetered,Data not expected - glider not available to send data
-#Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399422.dat,GA02HYPM-WFP03-03-DOSTAL000,telemetered,Data not expected - glider not available to send data
-#Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wc_wfp_1399422.dat,GA02HYPM-WFP03-04-CTDPFL000,telemetered,Data not expected - glider not available to send data
-#Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wa_wfp_1399422.dat,GA02HYPM-WFP03-05-VEL3DL000,telemetered,Data not expected - glider not available to send data
-Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*ctdmo*.dat,GA02HYPM-RIM01-02-CTDMOG039,telemetered,
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/node*p1_*.status_*.dat,GA02HYPM-RIM01-00-SIOENG000,telemetered,
-#Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399422.dat,GA02HYPM-WFP03-00-WFPENG000,telemetered,Data not expected - glider not available to send data
-#Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399421.dat,GA02HYPM-WFP02-00-WFPENG000,telemetered,Data not expected - glider not available to send data
-#,,GA02HYPM-MPM01-02-ZPLSGA009,telemetered,Not installed
-#,,GA02HYPM-MPM01-02-ZPLSGA010,telemetered,Not installed
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#,,GA02HYPM-MPM01-02-ZPLSGA009,telemetered,Not Deployed,Not installed
+#,,GA02HYPM-MPM01-02-ZPLSGA010,telemetered,Not Deployed,Not installed
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/node*p1_*.status_*.dat,GA02HYPM-RIM01-00-SIOENG000,telemetered,Available,
+Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*ctdmo*.dat,GA02HYPM-RIM01-02-CTDMOG039,telemetered,Available,
+#Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399421.dat,GA02HYPM-WFP02-00-WFPENG000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399421.dat,GA02HYPM-WFP02-01-FLORDL000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399421.dat,GA02HYPM-WFP02-03-DOSTAL000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wc_wfp_1399421.dat,GA02HYPM-WFP02-04-CTDPFL000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wa_wfp_1399421.dat,GA02HYPM-WFP02-05-VEL3DL000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399422.dat,GA02HYPM-WFP03-00-WFPENG000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399422.dat,GA02HYPM-WFP03-01-FLORDL000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.we_wfp_1399422.dat,GA02HYPM-WFP03-03-DOSTAL000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wc_wfp_1399422.dat,GA02HYPM-WFP03-04-CTDPFL000,telemetered,Not Expected,Data not expected - glider not available to send data
+#Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00002/*.wa_wfp_1399422.dat,GA02HYPM-WFP03-05-VEL3DL000,telemetered,Not Expected,Data not expected - glider not available to send data

--- a/GA02HYPM/GA02HYPM_D00003_ingest.csv
+++ b/GA02HYPM/GA02HYPM_D00003_ingest.csv
@@ -1,15 +1,15 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398821.dat,GA02HYPM-WFP02-01-FLORDL000,telemetered,
-Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398821.dat,GA02HYPM-WFP02-03-DOSTAL000,telemetered,
-Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wc_wfp_1398821.dat,GA02HYPM-WFP02-04-CTDPFL000,telemetered,No files on server
-Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wa_wfp_1398821.dat,GA02HYPM-WFP02-05-VEL3DL000,telemetered,
-Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398822.dat,GA02HYPM-WFP03-01-FLORDL000,telemetered,
-Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398822.dat,GA02HYPM-WFP03-03-DOSTAL000,telemetered,
-Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wc_wfp_1398822.dat,GA02HYPM-WFP03-04-CTDPFL000,telemetered,
-Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wa_wfp_1398822.dat,GA02HYPM-WFP03-05-VEL3DL000,telemetered,
-Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*ctdmo*.dat,GA02HYPM-RIM01-02-CTDMOG039,telemetered,
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/node*p1_*.status_*.dat,GA02HYPM-RIM01-00-SIOENG000,telemetered,
-Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398821.dat,GA02HYPM-WFP02-00-WFPENG000,telemetered,
-Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398822.dat,GA02HYPM-WFP03-00-WFPENG000,telemetered,
-#,,GA02HYPM-MPM01-02-ZPLSGA009,telemetered,Issues with data - MIO investigating
-#,,GA02HYPM-MPM01-02-ZPLSGA010,telemetered,Issues with data - MIO investigating
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#,,GA02HYPM-MPM01-02-ZPLSGA009,telemetered,Missing,Issues with data - MIO investigating
+#,,GA02HYPM-MPM01-02-ZPLSGA010,telemetered,Missing,Issues with data - MIO investigating
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/node*p1_*.status_*.dat,GA02HYPM-RIM01-00-SIOENG000,telemetered,Available,
+Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*ctdmo*.dat,GA02HYPM-RIM01-02-CTDMOG039,telemetered,Available,
+Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398821.dat,GA02HYPM-WFP02-00-WFPENG000,telemetered,Available,
+Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398821.dat,GA02HYPM-WFP02-01-FLORDL000,telemetered,Available,
+Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398821.dat,GA02HYPM-WFP02-03-DOSTAL000,telemetered,Available,
+Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wc_wfp_1398821.dat,GA02HYPM-WFP02-04-CTDPFL000,telemetered,Missing,No files on server
+Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wa_wfp_1398821.dat,GA02HYPM-WFP02-05-VEL3DL000,telemetered,Available,
+Ingest.wfp-eng-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398822.dat,GA02HYPM-WFP03-00-WFPENG000,telemetered,Available,
+Ingest.flord-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398822.dat,GA02HYPM-WFP03-01-FLORDL000,telemetered,Available,
+Ingest.dosta-ln-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.we_wfp_1398822.dat,GA02HYPM-WFP03-03-DOSTAL000,telemetered,Available,
+Ingest.ctdpf-ckl-wfp-sio-mule_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wc_wfp_1398822.dat,GA02HYPM-WFP03-04-CTDPFL000,telemetered,Available,
+Ingest.vel3d-l-wfp-sio_telemetered,/omc_data/whoi/OMC/GA02HYPM/D00003/*.wa_wfp_1398822.dat,GA02HYPM-WFP03-05-VEL3DL000,telemetered,Available,

--- a/GA02HYPM/GA02HYPM_R00001_ingest.csv
+++ b/GA02HYPM/GA02HYPM_R00001_ingest.csv
@@ -1,16 +1,16 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.vel3d-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/A*.DA?,GA02HYPM-WFP02-05-VEL3DL000,recovered_wfp,
-Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/C*.DA?,GA02HYPM-WFP02-04-CTDPFL000,recovered_wfp,
-Ingest.dosta-ln-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/E*.DA?,GA02HYPM-WFP02-03-DOSTAL000,recovered_wfp,
-Ingest.flord-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/E*.DA?,GA02HYPM-WFP02-01-FLORDL000,recovered_wfp,
-Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/E*.DA?,GA02HYPM-WFP02-00-WFPENG000,recovered_wfp,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/CTDMO-G_sn12406/*.hex,GA02HYPM-RIM01-02-CTDMOG039,recovered_inst,
-#Ingest.ctdmo-ghqr-sio_ctRecovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/CTDMO-G_sn12406/*.DAT,GA02HYPM-RIM01-02-CTDMOG039,recovered_host,Data not expected
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/MSIOC_sn/STA*.DA?,GA02HYPM-RIM01-00-SIOENG000,recovered_host,
-#,,GA02HYPM-MPM01-02-ZPLSGA009,recovered_inst,Not installed
-#,,GA02HYPM-MPM01-02-ZPLSGA010,recovered_inst,Not installed
-Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/E*.DA?,GA02HYPM-WFP03-00-WFPENG000,recovered_wfp,
-Ingest.flord-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/E*.DA?,GA02HYPM-WFP03-01-FLORDL000,recovered_wfp,
-Ingest.dosta-ln-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/E*.DA?,GA02HYPM-WFP03-03-DOSTAL000,recovered_wfp,
-Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/C*.DA?,GA02HYPM-WFP03-04-CTDPFL000,recovered_wfp,
-Ingest.vel3d-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/A*.DA?,GA02HYPM-WFP03-05-VEL3DL000,recovered_wfp,
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#,,GA02HYPM-MPM01-02-ZPLSGA009,recovered_inst,Not Deployed,Not installed
+#,,GA02HYPM-MPM01-02-ZPLSGA010,recovered_inst,Not Deployed,Not installed
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/MSIOC_sn/STA*.DA?,GA02HYPM-RIM01-00-SIOENG000,recovered_host,Available,
+#Ingest.ctdmo-ghqr-sio_ctRecovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/CTDMO-G_sn12406/*.DAT,GA02HYPM-RIM01-02-CTDMOG039,recovered_host,Not Expected,Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/CTDMO-G_sn12406/*.hex,GA02HYPM-RIM01-02-CTDMOG039,recovered_inst,Available,
+Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/E*.DA?,GA02HYPM-WFP02-00-WFPENG000,recovered_wfp,Available,
+Ingest.flord-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/E*.DA?,GA02HYPM-WFP02-01-FLORDL000,recovered_wfp,Available,
+Ingest.dosta-ln-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/E*.DA?,GA02HYPM-WFP02-03-DOSTAL000,recovered_wfp,Available,
+Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/C*.DA?,GA02HYPM-WFP02-04-CTDPFL000,recovered_wfp,Available,
+Ingest.vel3d-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/UPPER_sn13104-04/00000/A*.DA?,GA02HYPM-WFP02-05-VEL3DL000,recovered_wfp,Available,
+Ingest.wfp-eng-stc-imodem_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/E*.DA?,GA02HYPM-WFP03-00-WFPENG000,recovered_wfp,Available,
+Ingest.flord-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/E*.DA?,GA02HYPM-WFP03-01-FLORDL000,recovered_wfp,Available,
+Ingest.dosta-ln-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/E*.DA?,GA02HYPM-WFP03-03-DOSTAL000,recovered_wfp,Available,
+Ingest.ctdpf-ckl-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/C*.DA?,GA02HYPM-WFP03-04-CTDPFL000,recovered_wfp,Available,
+Ingest.vel3d-l-wfp_recovered,/omc_data/whoi/OMC/GA02HYPM/R00001/cg_data/dcl00/LOWER_sn13104-06/00000/A*.DA?,GA02HYPM-WFP03-05-VEL3DL000,recovered_wfp,Available,

--- a/GA02HYPM/GA02HYPM_R00002_ingest.csv
+++ b/GA02HYPM/GA02HYPM_R00002_ingest.csv
@@ -1,16 +1,16 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.vel3d-l-wfp_recovered,,GA02HYPM-WFP02-05-VEL3DL000,recovered_wfp,Mooring not recovered
-#Ingest.ctdpf-ckl-wfp_recovered,,GA02HYPM-WFP02-04-CTDPFL000,recovered_wfp,Mooring not recovered
-#Ingest.dosta-ln-wfp_recovered,,GA02HYPM-WFP02-03-DOSTAL000,recovered_wfp,Mooring not recovered
-#Ingest.flord-l-wfp_recovered,,GA02HYPM-WFP02-01-FLORDL000,recovered_wfp,Mooring not recovered
-#Ingest.wfp-eng-stc-imodem_recovered,,GA02HYPM-WFP02-00-WFPENG000,recovered_wfp,Mooring not recovered
-#Ingest.ctdmo-ghqr_recovered,,GA02HYPM-RIM01-02-CTDMOG039,recovered_inst,Mooring not recovered
-#Ingest.ctdmo-ghqr-sio_ctRecovered,,GA02HYPM-RIM01-02-CTDMOG039,recovered_host,Mooring not recovered
-#Ingest.sio-eng-sio_recovered,,GA02HYPM-RIM01-00-SIOENG000,recovered_host,Mooring not recovered
-#,,GA02HYPM-MPM01-02-ZPLSGA009,recovered_inst,Not installed
-#,,GA02HYPM-MPM01-02-ZPLSGA010,recovered_inst,Not installed
-#Ingest.wfp-eng-stc-imodem_recovered,,GA02HYPM-WFP03-00-WFPENG000,recovered_wfp,Mooring not recovered
-#Ingest.flord-l-wfp_recovered,,GA02HYPM-WFP03-01-FLORDL000,recovered_wfp,Mooring not recovered
-#Ingest.dosta-ln-wfp_recovered,,GA02HYPM-WFP03-03-DOSTAL000,recovered_wfp,Mooring not recovered
-#Ingest.ctdpf-ckl-wfp_recovered,,GA02HYPM-WFP03-04-CTDPFL000,recovered_wfp,Mooring not recovered
-#Ingest.vel3d-l-wfp_recovered,,GA02HYPM-WFP03-05-VEL3DL000,recovered_wfp,Mooring not recovered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#,,GA02HYPM-MPM01-02-ZPLSGA009,recovered_inst,Not Deployed,Not installed
+#,,GA02HYPM-MPM01-02-ZPLSGA010,recovered_inst,Not Deployed,Not installed
+#Ingest.sio-eng-sio_recovered,,GA02HYPM-RIM01-00-SIOENG000,recovered_host,Not Expected,Mooring not recovered
+#Ingest.ctdmo-ghqr-sio_ctRecovered,,GA02HYPM-RIM01-02-CTDMOG039,recovered_host,Not Expected,Mooring not recovered
+#Ingest.ctdmo-ghqr_recovered,,GA02HYPM-RIM01-02-CTDMOG039,recovered_inst,Not Expected,Mooring not recovered
+#Ingest.wfp-eng-stc-imodem_recovered,,GA02HYPM-WFP02-00-WFPENG000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.flord-l-wfp_recovered,,GA02HYPM-WFP02-01-FLORDL000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.dosta-ln-wfp_recovered,,GA02HYPM-WFP02-03-DOSTAL000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.ctdpf-ckl-wfp_recovered,,GA02HYPM-WFP02-04-CTDPFL000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.vel3d-l-wfp_recovered,,GA02HYPM-WFP02-05-VEL3DL000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.wfp-eng-stc-imodem_recovered,,GA02HYPM-WFP03-00-WFPENG000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.flord-l-wfp_recovered,,GA02HYPM-WFP03-01-FLORDL000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.dosta-ln-wfp_recovered,,GA02HYPM-WFP03-03-DOSTAL000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.ctdpf-ckl-wfp_recovered,,GA02HYPM-WFP03-04-CTDPFL000,recovered_wfp,Not Expected,Mooring not recovered
+#Ingest.vel3d-l-wfp_recovered,,GA02HYPM-WFP03-05-VEL3DL000,recovered_wfp,Not Expected,Mooring not recovered

--- a/GA03FLMA/GA03FLMA_D00001_ingest.csv
+++ b/GA03FLMA/GA03FLMA_D00001_ingest.csv
@@ -1,20 +1,19 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*flort*.dat,GA03FLMA-RIS01-05-FLORTD000,telemetered,
-Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*phsen*.dat,GA03FLMA-RIS01-04-PHSENF000,telemetered,
-Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*dosta*.dat,GA03FLMA-RIS01-03-DOSTAD000,telemetered,
-Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*adcps*.dat,GA03FLMA-RIM01-02-ADCPSL003,telemetered,
-Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG000,telemetered,Wildcard refdes
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*status_1398901.dat,GA03FLMA-RIS01-00-SIOENG000,telemetered,
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*status_1399501.dat,GA03FLMA-RIM01-00-SIOENG000,telemetered,
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG040,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG041,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG042,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG043,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG044,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG045,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG046,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG047,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG048,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH049,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH050,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH051,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*status_1399501.dat,GA03FLMA-RIM01-00-SIOENG000,telemetered,Available,
+Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*adcps*.dat,GA03FLMA-RIM01-02-ADCPSL003,telemetered,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG040,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG041,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG042,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG043,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG044,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG045,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG046,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG047,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG048,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH049,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH050,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00001/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH051,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*status_1398901.dat,GA03FLMA-RIS01-00-SIOENG000,telemetered,Available,
+Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*dosta*.dat,GA03FLMA-RIS01-03-DOSTAD000,telemetered,Available,
+Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*phsen*.dat,GA03FLMA-RIS01-04-PHSENF000,telemetered,Available,
+Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00001/*flort*.dat,GA03FLMA-RIS01-05-FLORTD000,telemetered,Available,

--- a/GA03FLMA/GA03FLMA_D00002_ingest.csv
+++ b/GA03FLMA/GA03FLMA_D00002_ingest.csv
@@ -1,20 +1,19 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*flort*.dat,GA03FLMA-RIS01-05-FLORTD000,telemetered,
-Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*phsen*.dat,GA03FLMA-RIS01-04-PHSENF000,telemetered,
-Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*dosta*.dat,GA03FLMA-RIS01-03-DOSTAD000,telemetered,
-Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*adcps*.dat,GA03FLMA-RIM01-02-ADCPSL003,telemetered,
-Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG000,telemetered,Wildcard refdes
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*status_1487501.dat,GA03FLMA-RIS01-00-SIOENG000,telemetered,
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*status_1487901.dat,GA03FLMA-RIM01-00-SIOENG000,telemetered,
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG040,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG041,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG042,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG043,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG044,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG045,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG046,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG047,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG048,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH049,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH050,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH051,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*status_1487901.dat,GA03FLMA-RIM01-00-SIOENG000,telemetered,Available,
+Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*adcps*.dat,GA03FLMA-RIM01-02-ADCPSL003,telemetered,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG040,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG041,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG042,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG043,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG044,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG045,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG046,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG047,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG048,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH049,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH050,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMA/D00002/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH051,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*status_1487501.dat,GA03FLMA-RIS01-00-SIOENG000,telemetered,Available,
+Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*dosta*.dat,GA03FLMA-RIS01-03-DOSTAD000,telemetered,Available,
+Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*phsen*.dat,GA03FLMA-RIS01-04-PHSENF000,telemetered,Available,
+Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00002/*flort*.dat,GA03FLMA-RIS01-05-FLORTD000,telemetered,Available,

--- a/GA03FLMA/GA03FLMA_D00003_ingest.csv
+++ b/GA03FLMA/GA03FLMA_D00003_ingest.csv
@@ -1,20 +1,19 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*flort*.dat,GA03FLMA-RIS01-05-FLORTD000,telemetered,No data expected due to glider failures
-#Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*phsen*.dat,GA03FLMA-RIS01-04-PHSENF000,telemetered,No data expected due to glider failures
-#Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*dosta*.dat,GA03FLMA-RIS01-03-DOSTAD000,telemetered,No data expected due to glider failures
-#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*adcps*.dat,GA03FLMA-RIM01-02-ADCPSL003,telemetered,No data expected due to glider failures
-#Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG000,telemetered,Wildcard refdes. No data expected due to glider failures
-#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*status_1487501.dat,GA03FLMA-RIS01-00-SIOENG000,telemetered,No data expected due to glider failures
-#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*status_1487901.dat,GA03FLMA-RIM01-00-SIOENG000,telemetered,No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG040,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG041,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG042,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG043,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG044,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG045,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG046,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG047,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG048,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH049,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH050,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH051,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*status_1487901.dat,GA03FLMA-RIM01-00-SIOENG000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*adcps*.dat,GA03FLMA-RIM01-02-ADCPSL003,telemetered,Not Expected,No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG040,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG041,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG042,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG043,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG044,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG045,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG046,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG047,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOG048,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH049,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH050,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMA/D00003/*ctdmo*.dat,GA03FLMA-RIM01-02-CTDMOH051,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*status_1487501.dat,GA03FLMA-RIS01-00-SIOENG000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*dosta*.dat,GA03FLMA-RIS01-03-DOSTAD000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*phsen*.dat,GA03FLMA-RIS01-04-PHSENF000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/D00003/*flort*.dat,GA03FLMA-RIS01-05-FLORTD000,telemetered,Not Expected,No data expected due to glider failures

--- a/GA03FLMA/GA03FLMA_R00001_ingest.csv
+++ b/GA03FLMA/GA03FLMA_R00001_ingest.csv
@@ -1,34 +1,33 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/ADCPS_sn20503/*.000,GA03FLMA-RIM01-02-ADCPSL003,recovered_inst,
-#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/ADCPS_sn20503/ADC*.DAT,GA03FLMA-RIM01-02-ADCPSL003,recovered_host,Data not expected
-Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/DOSTA_sn428/DOS*.DAT,GA03FLMA-RIS01-03-DOSTAD000,recovered_host,
-Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/FLORD_sn1215/FLO*.DAT,GA03FLMA-RIS01-05-FLORTD000,recovered_host,
-Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/PHSEN_snP0141/SAMI*.txt,GA03FLMA-RIS01-04-PHSENF000,recovered_inst,
-#Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/PHSEN_snP0141/PHS*.DAT,GA03FLMA-RIS01-04-PHSENF000,recovered_host,Data not expected
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12401/*.hex,GA03FLMA-RIM01-02-CTDMOG040,recovered_inst,29
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12584/*.hex,GA03FLMA-RIM01-02-CTDMOG041,recovered_inst,39
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12408/*.hex,GA03FLMA-RIM01-02-CTDMOG042,recovered_inst,59
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12608/*.hex,GA03FLMA-RIM01-02-CTDMOG043,recovered_inst,90
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12609/*.hex,GA03FLMA-RIM01-02-CTDMOG044,recovered_inst,130
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12409/*.hex,GA03FLMA-RIM01-02-CTDMOG045,recovered_inst,180
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12412/*.hex,GA03FLMA-RIM01-02-CTDMOG046,recovered_inst,250
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12410/*.hex,GA03FLMA-RIM01-02-CTDMOG047,recovered_inst,350
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12396/*.hex,GA03FLMA-RIM01-02-CTDMOG048,recovered_inst,501
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12394/*.hex,GA03FLMA-RIM01-02-CTDMOH049,recovered_inst,748
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12618/*.hex,GA03FLMA-RIM01-02-CTDMOH050,recovered_inst,999
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12619/*.hex,GA03FLMA-RIM01-02-CTDMOH051,recovered_inst,1501
-#Ingest.ctdmo-ghqr-sio_ctRecovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG000,recovered_host,Wildcard refdes. Data not expected
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/MSIOC/STA*.DAT,GA03FLMA-RIM01-00-SIOENG000,recovered_host,
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/SSIOC/STA*.DAT,GA03FLMA-RIS01-00-SIOENG000,recovered_host,
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG040,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG041,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG042,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG043,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG044,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG045,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG046,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG047,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG048,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOH049,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOH050,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOH051,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/MSIOC/STA*.DAT,GA03FLMA-RIM01-00-SIOENG000,recovered_host,Available,
+#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/ADCPS_sn20503/ADC*.DAT,GA03FLMA-RIM01-02-ADCPSL003,recovered_host,Not Expected,Data not expected
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/ADCPS_sn20503/*.000,GA03FLMA-RIM01-02-ADCPSL003,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG040,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12401/*.hex,GA03FLMA-RIM01-02-CTDMOG040,recovered_inst,Available,29
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG041,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12584/*.hex,GA03FLMA-RIM01-02-CTDMOG041,recovered_inst,Available,39
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG042,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12408/*.hex,GA03FLMA-RIM01-02-CTDMOG042,recovered_inst,Available,59
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG043,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12608/*.hex,GA03FLMA-RIM01-02-CTDMOG043,recovered_inst,Available,90
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG044,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12609/*.hex,GA03FLMA-RIM01-02-CTDMOG044,recovered_inst,Available,130
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG045,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12409/*.hex,GA03FLMA-RIM01-02-CTDMOG045,recovered_inst,Available,180
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG046,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12412/*.hex,GA03FLMA-RIM01-02-CTDMOG046,recovered_inst,Available,250
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG047,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12410/*.hex,GA03FLMA-RIM01-02-CTDMOG047,recovered_inst,Available,350
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOG048,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12396/*.hex,GA03FLMA-RIM01-02-CTDMOG048,recovered_inst,Available,501
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOH049,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12394/*.hex,GA03FLMA-RIM01-02-CTDMOH049,recovered_inst,Available,748
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOH050,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12618/*.hex,GA03FLMA-RIM01-02-CTDMOH050,recovered_inst,Available,999
+#,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMA-RIM01-02-CTDMOH051,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/CTDMO_sn12619/*.hex,GA03FLMA-RIM01-02-CTDMOH051,recovered_inst,Available,1501
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/SSIOC/STA*.DAT,GA03FLMA-RIS01-00-SIOENG000,recovered_host,Available,
+Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/DOSTA_sn428/DOS*.DAT,GA03FLMA-RIS01-03-DOSTAD000,recovered_host,Available,
+Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/PHSEN_snP0141/SAMI*.txt,GA03FLMA-RIS01-04-PHSENF000,recovered_inst,Available,
+#Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/PHSEN_snP0141/PHS*.DAT,GA03FLMA-RIS01-04-PHSENF000,recovered_host,Not Expected,Data not expected
+Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00001/cg_data/dcl00/FLORD_sn1215/FLO*.DAT,GA03FLMA-RIS01-05-FLORTD000,recovered_host,Available,

--- a/GA03FLMA/GA03FLMA_R00002_ingest.csv
+++ b/GA03FLMA/GA03FLMA_R00002_ingest.csv
@@ -1,34 +1,33 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/ADCPS_sn23497/*.000,GA03FLMA-RIM01-02-ADCPSL003,recovered_inst,
-Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/ADCPS/ADC*.DAT,GA03FLMA-RIM01-02-ADCPSL003,recovered_host,
-Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/DOSTA/DOS*.DAT,GA03FLMA-RIS01-03-DOSTAD000,recovered_host,
-Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/FLORT/FLO*.DAT,GA03FLMA-RIS01-05-FLORTD000,recovered_host,
-Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/PHSEN_snP0181/SAMI*.txt,GA03FLMA-RIS01-04-PHSENF000,recovered_inst,
-Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/PHSEN/PHS*.DAT,GA03FLMA-RIS01-04-PHSENF000,recovered_host,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13560/*.hex,GA03FLMA-RIM01-02-CTDMOG040,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13561/*.hex,GA03FLMA-RIM01-02-CTDMOG041,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13578/*.hex,GA03FLMA-RIM01-02-CTDMOG042,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13579/*.hex,GA03FLMA-RIM01-02-CTDMOG043,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13589/*.hex,GA03FLMA-RIM01-02-CTDMOG044,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13590/*.hex,GA03FLMA-RIM01-02-CTDMOG045,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13593/*.hex,GA03FLMA-RIM01-02-CTDMOG046,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13594/*.hex,GA03FLMA-RIM01-02-CTDMOG047,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13595/*.hex,GA03FLMA-RIM01-02-CTDMOG048,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13627/*.hex,GA03FLMA-RIM01-02-CTDMOH049,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13631/*.hex,GA03FLMA-RIM01-02-CTDMOH050,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13632/*.hex,GA03FLMA-RIM01-02-CTDMOH051,recovered_inst,
-Ingest.ctdmo-ghqr-sio_ctRecovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG000,recovered_host,Wildcard refdes
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/STATUS/STA*.DAT,GA03FLMA-RIM01-00-SIOENG000,recovered_host,
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/STATUS/STA*.DAT,GA03FLMA-RIS01-00-SIOENG000,recovered_host,
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG040,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG041,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG042,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG043,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG044,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG045,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG046,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG047,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG048,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOH049,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOH050,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOH051,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/STATUS/STA*.DAT,GA03FLMA-RIM01-00-SIOENG000,recovered_host,Available,
+Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/ADCPS/ADC*.DAT,GA03FLMA-RIM01-02-ADCPSL003,recovered_host,Available,
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/ADCPS_sn23497/*.000,GA03FLMA-RIM01-02-ADCPSL003,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG040,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13560/*.hex,GA03FLMA-RIM01-02-CTDMOG040,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG041,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13561/*.hex,GA03FLMA-RIM01-02-CTDMOG041,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG042,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13578/*.hex,GA03FLMA-RIM01-02-CTDMOG042,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG043,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13579/*.hex,GA03FLMA-RIM01-02-CTDMOG043,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG044,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13589/*.hex,GA03FLMA-RIM01-02-CTDMOG044,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG045,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13590/*.hex,GA03FLMA-RIM01-02-CTDMOG045,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG046,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13593/*.hex,GA03FLMA-RIM01-02-CTDMOG046,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG047,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13594/*.hex,GA03FLMA-RIM01-02-CTDMOG047,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOG048,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13595/*.hex,GA03FLMA-RIM01-02-CTDMOG048,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOH049,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13627/*.hex,GA03FLMA-RIM01-02-CTDMOH049,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOH050,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13631/*.hex,GA03FLMA-RIM01-02-CTDMOH050,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/MSIOC_sn14875/CTD/*.DAT,GA03FLMA-RIM01-02-CTDMOH051,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/CTDMO_sn37-13632/*.hex,GA03FLMA-RIM01-02-CTDMOH051,recovered_inst,Available,
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/STATUS/STA*.DAT,GA03FLMA-RIS01-00-SIOENG000,recovered_host,Available,
+Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/DOSTA/DOS*.DAT,GA03FLMA-RIS01-03-DOSTAD000,recovered_host,Available,
+Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/instruments/PHSEN_snP0181/SAMI*.txt,GA03FLMA-RIS01-04-PHSENF000,recovered_inst,Available,
+Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/PHSEN/PHS*.DAT,GA03FLMA-RIS01-04-PHSENF000,recovered_host,Available,
+Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMA/R00002/cg_data/SSIOC_sn14879/FLORT/FLO*.DAT,GA03FLMA-RIS01-05-FLORTD000,recovered_host,Available,

--- a/GA03FLMB/GA03FLMB_D00001_ingest.csv
+++ b/GA03FLMB/GA03FLMB_D00001_ingest.csv
@@ -1,20 +1,19 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*flort*.dat,GA03FLMB-RIS01-05-FLORTD000,telemetered,
-Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*phsen*.dat,GA03FLMB-RIS01-04-PHSENF000,telemetered,
-Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*dosta*.dat,GA03FLMB-RIS01-03-DOSTAD000,telemetered,
-Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*adcps*.dat,GA03FLMB-RIM01-02-ADCPSL007,telemetered,
-Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG000,telemetered,Wildcard refdes
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*status_1399601.dat,GA03FLMB-RIS01-00-SIOENG000,telemetered,
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*status_1399801.dat,GA03FLMB-RIM01-00-SIOENG000,telemetered,
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG060,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG061,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG062,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG063,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG064,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG065,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG066,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG067,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG068,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH069,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH070,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH071,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*status_1399801.dat,GA03FLMB-RIM01-00-SIOENG000,telemetered,Available,
+Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*adcps*.dat,GA03FLMB-RIM01-02-ADCPSL007,telemetered,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG060,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG061,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG062,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG063,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG064,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG065,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG066,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG067,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG068,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH069,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH070,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00001/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH071,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*status_1399601.dat,GA03FLMB-RIS01-00-SIOENG000,telemetered,Available,
+Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*dosta*.dat,GA03FLMB-RIS01-03-DOSTAD000,telemetered,Available,
+Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*phsen*.dat,GA03FLMB-RIS01-04-PHSENF000,telemetered,Available,
+Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00001/*flort*.dat,GA03FLMB-RIS01-05-FLORTD000,telemetered,Available,

--- a/GA03FLMB/GA03FLMB_D00002_ingest.csv
+++ b/GA03FLMB/GA03FLMB_D00002_ingest.csv
@@ -1,20 +1,19 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*flort*.dat,GA03FLMB-RIS01-05-FLORTD000,telemetered,
-Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*phsen*.dat,GA03FLMB-RIS01-04-PHSENF000,telemetered,
-Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*dosta*.dat,GA03FLMB-RIS01-03-DOSTAD000,telemetered,
-Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*adcps*.dat,GA03FLMB-RIM01-02-ADCPSL007,telemetered,
-Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG000,telemetered,Wildcard refdes
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*status_1488201.dat,GA03FLMB-RIS01-00-SIOENG000,telemetered,
-Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*status_1488101.dat,GA03FLMB-RIM01-00-SIOENG000,telemetered,
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG060,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG061,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG062,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG063,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG064,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG065,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG066,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG067,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG068,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH069,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH070,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH071,telemetered,Data assigned to refdes after ingestion with wildcard refdes.
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*status_1488101.dat,GA03FLMB-RIM01-00-SIOENG000,telemetered,Available,
+Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*adcps*.dat,GA03FLMB-RIM01-02-ADCPSL007,telemetered,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG060,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG061,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG062,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG063,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG064,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG065,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG066,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG067,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG068,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH069,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH070,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+#,/omc_data/whoi/OMC/GA03FLMB/D00002/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH071,telemetered,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*status_1488201.dat,GA03FLMB-RIS01-00-SIOENG000,telemetered,Available,
+Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*dosta*.dat,GA03FLMB-RIS01-03-DOSTAD000,telemetered,Available,
+Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*phsen*.dat,GA03FLMB-RIS01-04-PHSENF000,telemetered,Available,
+Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00002/*flort*.dat,GA03FLMB-RIS01-05-FLORTD000,telemetered,Available,

--- a/GA03FLMB/GA03FLMB_D00003_ingest.csv
+++ b/GA03FLMB/GA03FLMB_D00003_ingest.csv
@@ -1,20 +1,19 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*flort*.dat,GA03FLMB-RIS01-05-FLORTD000,telemetered,No data expected due to glider failures
-#Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*phsen*.dat,GA03FLMB-RIS01-04-PHSENF000,telemetered,No data expected due to glider failures
-#Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*dosta*.dat,GA03FLMB-RIS01-03-DOSTAD000,telemetered,No data expected due to glider failures
-#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*adcps*.dat,GA03FLMB-RIM01-02-ADCPSL007,telemetered,No data expected due to glider failures
-#Ingest.ctdmo-ghqr-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG000,telemetered,No data expected due to glider failures
-#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*status_1488201.dat,GA03FLMB-RIS01-00-SIOENG000,telemetered,No data expected due to glider failures
-#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*status_1488101.dat,GA03FLMB-RIM01-00-SIOENG000,telemetered,No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG060,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG061,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG062,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG063,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG064,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG065,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG066,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG067,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG068,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH069,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH070,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
-#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH071,telemetered,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*status_1488101.dat,GA03FLMB-RIM01-00-SIOENG000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*adcps*.dat,GA03FLMB-RIM01-02-ADCPSL007,telemetered,Not Expected,No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG060,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG061,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG062,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG063,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG064,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG065,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG066,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG067,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOG068,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH069,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH070,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#,/omc_data/whoi/OMC/GA03FLMB/D00003/*ctdmo*.dat,GA03FLMB-RIM01-02-CTDMOH071,telemetered,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. No data expected due to glider failures
+#Ingest.sio-eng-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*status_1488201.dat,GA03FLMB-RIS01-00-SIOENG000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.dosta-abcdjm-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*dosta*.dat,GA03FLMB-RIS01-03-DOSTAD000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.phsen-abcdef-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*phsen*.dat,GA03FLMB-RIS01-04-PHSENF000,telemetered,Not Expected,No data expected due to glider failures
+#Ingest.flort-dj-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/D00003/*flort*.dat,GA03FLMB-RIS01-05-FLORTD000,telemetered,Not Expected,No data expected due to glider failures

--- a/GA03FLMB/GA03FLMB_R00001_ingest.csv
+++ b/GA03FLMB/GA03FLMB_R00001_ingest.csv
@@ -1,34 +1,33 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/ADCPS_sn21497/*.000,GA03FLMB-RIM01-02-ADCPSL007,recovered_inst,
-#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/ADCPS_sn21497/ADC*.DAT,GA03FLMB-RIM01-02-ADCPSL007,recovered_host,Data not expected
-Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/DOSTA_sn427/DOS*.DAT,GA03FLMB-RIS01-03-DOSTAD000,recovered_host,
-Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/FLORD_sn1219/FLO*.DAT,GA03FLMB-RIS01-05-FLORTD000,recovered_host,
-Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/PHSEN_snP0142/SAMI*.txt,GA03FLMB-RIS01-04-PHSENF000,recovered_inst,
-#Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/PHSEN_snP0142/PHS*.DAT,GA03FLMB-RIS01-04-PHSENF000,recovered_host,Data not expected
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12403/*.hex,GA03FLMB-RIM01-02-CTDMOG060,recovered_inst,29
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12413/*.hex,GA03FLMB-RIM01-02-CTDMOG061,recovered_inst,39
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12404/*.hex,GA03FLMB-RIM01-02-CTDMOG062,recovered_inst,59
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12414/*.hex,GA03FLMB-RIM01-02-CTDMOG063,recovered_inst,90
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12407/*.hex,GA03FLMB-RIM01-02-CTDMOG064,recovered_inst,130
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn11605/*.hex,GA03FLMB-RIM01-02-CTDMOG065,recovered_inst,180
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn11651/*.hex,GA03FLMB-RIM01-02-CTDMOG066,recovered_inst,250
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn11610/*.hex,GA03FLMB-RIM01-02-CTDMOG067,recovered_inst,350
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12400/*.hex,GA03FLMB-RIM01-02-CTDMOG068,recovered_inst,501
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12395/*.hex,GA03FLMB-RIM01-02-CTDMOH069,recovered_inst,748
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12387/*.hex,GA03FLMB-RIM01-02-CTDMOH070,recovered_inst,999
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12388/*.hex,GA03FLMB-RIM01-02-CTDMOH071,recovered_inst,1501
-#Ingest.ctdmo-ghqr-sio_ctRecovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG000,recovered_host,Wildard refdes. Data not expected
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/MSIOC/STA*.DAT,GA03FLMB-RIM01-00-SIOENG000,recovered_host,
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/SSIOC/STA*.DAT,GA03FLMB-RIS01-00-SIOENG000,recovered_host,
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG060,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG061,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG062,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG063,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG064,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG065,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG066,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG067,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG068,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOH069,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOH070,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
-#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOH071,recovered_host,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/MSIOC/STA*.DAT,GA03FLMB-RIM01-00-SIOENG000,recovered_host,Available,
+#Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/ADCPS_sn21497/ADC*.DAT,GA03FLMB-RIM01-02-ADCPSL007,recovered_host,Not Expected,Data not expected
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/ADCPS_sn21497/*.000,GA03FLMB-RIM01-02-ADCPSL007,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG060,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12403/*.hex,GA03FLMB-RIM01-02-CTDMOG060,recovered_inst,Available,29
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG061,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12413/*.hex,GA03FLMB-RIM01-02-CTDMOG061,recovered_inst,Available,39
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG062,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12404/*.hex,GA03FLMB-RIM01-02-CTDMOG062,recovered_inst,Available,59
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG063,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12414/*.hex,GA03FLMB-RIM01-02-CTDMOG063,recovered_inst,Available,90
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG064,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12407/*.hex,GA03FLMB-RIM01-02-CTDMOG064,recovered_inst,Available,130
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG065,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn11605/*.hex,GA03FLMB-RIM01-02-CTDMOG065,recovered_inst,Available,180
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG066,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn11651/*.hex,GA03FLMB-RIM01-02-CTDMOG066,recovered_inst,Available,250
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG067,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn11610/*.hex,GA03FLMB-RIM01-02-CTDMOG067,recovered_inst,Available,350
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOG068,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12400/*.hex,GA03FLMB-RIM01-02-CTDMOG068,recovered_inst,Available,501
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOH069,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12395/*.hex,GA03FLMB-RIM01-02-CTDMOH069,recovered_inst,Available,748
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOH070,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12387/*.hex,GA03FLMB-RIM01-02-CTDMOH070,recovered_inst,Available,999
+#,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMOs_all/*.DAT,GA03FLMB-RIM01-02-CTDMOH071,recovered_host,Not Expected,Data assigned to refdes after ingestion with wildcard refdes. Data not expected
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/CTDMO_sn12388/*.hex,GA03FLMB-RIM01-02-CTDMOH071,recovered_inst,Available,1501
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/SSIOC/STA*.DAT,GA03FLMB-RIS01-00-SIOENG000,recovered_host,Available,
+Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/DOSTA_sn427/DOS*.DAT,GA03FLMB-RIS01-03-DOSTAD000,recovered_host,Available,
+Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/PHSEN_snP0142/SAMI*.txt,GA03FLMB-RIS01-04-PHSENF000,recovered_inst,Available,
+#Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/PHSEN_snP0142/PHS*.DAT,GA03FLMB-RIS01-04-PHSENF000,recovered_host,Not Expected,Data not expected
+Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00001/cg_data/dcl00/FLORD_sn1219/FLO*.DAT,GA03FLMB-RIS01-05-FLORTD000,recovered_host,Available,

--- a/GA03FLMB/GA03FLMB_R00002_ingest.csv
+++ b/GA03FLMB/GA03FLMB_R00002_ingest.csv
@@ -1,34 +1,33 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/ADCPS_sn23498/*.000,GA03FLMB-RIM01-02-ADCPSL007,recovered_inst,
-Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/ADCPS/ADC*.DAT,GA03FLMB-RIM01-02-ADCPSL007,recovered_host,
-Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/DOSTA/DOS*.DAT,GA03FLMB-RIS01-03-DOSTAD000,recovered_host,
-Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/FLORT/FLO*.DAT,GA03FLMB-RIS01-05-FLORTD000,recovered_host,
-Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/PHSEN_snP0180/SAMI*.txt,GA03FLMB-RIS01-04-PHSENF000,recovered_inst,
-Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/PHSEN/PHS*.DAT,GA03FLMB-RIS01-04-PHSENF000,recovered_host,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13596/*.hex,GA03FLMB-RIM01-02-CTDMOG060,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13597/*.hex,GA03FLMB-RIM01-02-CTDMOG061,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13598/*.hex,GA03FLMB-RIM01-02-CTDMOG062,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13599/*.hex,GA03FLMB-RIM01-02-CTDMOG063,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13600/*.hex,GA03FLMB-RIM01-02-CTDMOG064,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13601/*.hex,GA03FLMB-RIM01-02-CTDMOG065,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13603/*.hex,GA03FLMB-RIM01-02-CTDMOG066,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13604/*.hex,GA03FLMB-RIM01-02-CTDMOG067,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13605/*.hex,GA03FLMB-RIM01-02-CTDMOG068,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13647/*.hex,GA03FLMB-RIM01-02-CTDMOH069,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13634/*.hex,GA03FLMB-RIM01-02-CTDMOH070,recovered_inst,
-Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13646/*.hex,GA03FLMB-RIM01-02-CTDMOH071,recovered_inst,
-Ingest.ctdmo-ghqr-sio_ctRecovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG000,recovered_host,Wildcard refdes
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/STATUS/STA*.DAT,GA03FLMB-RIM01-00-SIOENG000,recovered_host,
-Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/STATUS/STA*.DAT,GA03FLMB-RIS01-00-SIOENG000,recovered_host,
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG060,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG061,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG062,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG063,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG064,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG065,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG066,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG067,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG068,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOH069,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOH070,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
-#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOH071,recovered_host,Data assigned to refdes after ingestion with wildcard refdes.
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/STATUS/STA*.DAT,GA03FLMB-RIM01-00-SIOENG000,recovered_host,Available,
+Ingest.adcps-jln-sio_telemetered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/ADCPS/ADC*.DAT,GA03FLMB-RIM01-02-ADCPSL007,recovered_host,Available,
+Ingest.adcps-jln_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/ADCPS_sn23498/*.000,GA03FLMB-RIM01-02-ADCPSL007,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG060,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13596/*.hex,GA03FLMB-RIM01-02-CTDMOG060,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG061,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13597/*.hex,GA03FLMB-RIM01-02-CTDMOG061,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG062,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13598/*.hex,GA03FLMB-RIM01-02-CTDMOG062,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG063,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13599/*.hex,GA03FLMB-RIM01-02-CTDMOG063,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG064,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13600/*.hex,GA03FLMB-RIM01-02-CTDMOG064,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG065,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13601/*.hex,GA03FLMB-RIM01-02-CTDMOG065,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG066,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13603/*.hex,GA03FLMB-RIM01-02-CTDMOG066,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG067,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13604/*.hex,GA03FLMB-RIM01-02-CTDMOG067,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOG068,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13605/*.hex,GA03FLMB-RIM01-02-CTDMOG068,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOH069,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13647/*.hex,GA03FLMB-RIM01-02-CTDMOH069,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOH070,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13634/*.hex,GA03FLMB-RIM01-02-CTDMOH070,recovered_inst,Available,
+#,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/MSIOC_sn14882/CTD/*.DAT,GA03FLMB-RIM01-02-CTDMOH071,recovered_host,Available,Data assigned to refdes after ingestion with wildcard refdes.
+Ingest.ctdmo-ghqr_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/CTDMO_sn37-13646/*.hex,GA03FLMB-RIM01-02-CTDMOH071,recovered_inst,Available,
+Ingest.sio-eng-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/STATUS/STA*.DAT,GA03FLMB-RIS01-00-SIOENG000,recovered_host,Available,
+Ingest.dosta-abcdjm-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/DOSTA/DOS*.DAT,GA03FLMB-RIS01-03-DOSTAD000,recovered_host,Available,
+Ingest.phsen-abcdef_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/instruments/PHSEN_snP0180/SAMI*.txt,GA03FLMB-RIS01-04-PHSENF000,recovered_inst,Available,
+Ingest.phsen-abcdef-imodem_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/PHSEN/PHS*.DAT,GA03FLMB-RIS01-04-PHSENF000,recovered_host,Available,
+Ingest.flort-dj-sio_recovered,/omc_data/whoi/OMC/GA03FLMB/R00002/cg_data/SSIOC_sn14881/FLORT/FLO*.DAT,GA03FLMB-RIS01-05-FLORTD000,recovered_host,Available,

--- a/GA05MOAS-GL364/GA05MOAS-GL364_D00002_ingest.csv
+++ b/GA05MOAS-GL364/GA05MOAS-GL364_D00002_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-00-ENG000000,telemetered
-Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-01-FLORDM000,telemetered
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-02-DOSTAM000,telemetered
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-04-CTDGVM000,telemetered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-00-ENG000000,telemetered,Available,
+Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-01-FLORDM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-02-DOSTAM000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL364/D00002/merged-from-glider/ga_*.mrg,GA05MOAS-GL364-04-CTDGVM000,telemetered,Available,

--- a/GA05MOAS-GL470/GA05MOAS-GL470_D00001_ingest.csv
+++ b/GA05MOAS-GL470/GA05MOAS-GL470_D00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-00-ENG000000,telemetered
-Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-01-FLORDM000,telemetered
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-02-DOSTAM000,telemetered
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-04-CTDGVM000,telemetered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-00-ENG000000,telemetered,Available,
+Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-01-FLORDM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-02-DOSTAM000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL470/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL470-04-CTDGVM000,telemetered,Available,

--- a/GA05MOAS-GL493/GA05MOAS-GL493_D00001_ingest.csv
+++ b/GA05MOAS-GL493/GA05MOAS-GL493_D00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-00-ENG000000,telemetered
-Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-01-FLORDM000,telemetered
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-02-DOSTAM000,telemetered
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-04-CTDGVM000,telemetered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-00-ENG000000,telemetered,Available,
+Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-01-FLORDM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-02-DOSTAM000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL493/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL493-04-CTDGVM000,telemetered,Available,

--- a/GA05MOAS-GL493/GA05MOAS-GL493_R00001_ingest.csv
+++ b/GA05MOAS-GL493/GA05MOAS-GL493_R00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-00-ENG000000,recovered_host
-Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-01-FLORDM000,recovered_host
-Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-02-DOSTAM000,recovered_host
-Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-04-CTDGVM000,recovered_host
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-00-ENG000000,recovered_host,Available,
+Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-01-FLORDM000,recovered_host,Available,
+Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-02-DOSTAM000,recovered_host,Available,
+Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL493/R00001/merged/ga_*.mrg,GA05MOAS-GL493-04-CTDGVM000,recovered_host,Available,

--- a/GA05MOAS-GL494/GA05MOAS-GL494_D00001_ingest.csv
+++ b/GA05MOAS-GL494/GA05MOAS-GL494_D00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-00-ENG000000,telemetered
-Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-01-FLORDM000,telemetered
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-02-DOSTAM000,telemetered
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-04-CTDGVM000,telemetered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-00-ENG000000,telemetered,Available,
+Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-01-FLORDM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-02-DOSTAM000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL494/D00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-04-CTDGVM000,telemetered,Available,

--- a/GA05MOAS-GL494/GA05MOAS-GL494_R00001_ingest.csv
+++ b/GA05MOAS-GL494/GA05MOAS-GL494_R00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-00-ENG000000,recovered_host,Glider lost
-#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-01-FLORDM000,recovered_host,Glider lost
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-02-DOSTAM000,recovered_host,Glider lost
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-04-CTDGVM000,recovered_host,Glider lost
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-00-ENG000000,recovered_host,Not Expected,Glider lost
+#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-01-FLORDM000,recovered_host,Not Expected,Glider lost
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-02-DOSTAM000,recovered_host,Not Expected,Glider lost
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL494/R00001/merged-from-glider/ga_494*.mrg,GA05MOAS-GL494-04-CTDGVM000,recovered_host,Not Expected,Glider lost

--- a/GA05MOAS-GL495/GA05MOAS-GL495_D00001_ingest.csv
+++ b/GA05MOAS-GL495/GA05MOAS-GL495_D00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-00-ENG000000,telemetered
-Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-01-FLORDM000,telemetered
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-02-DOSTAM000,telemetered
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-04-CTDGVM000,telemetered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-00-ENG000000,telemetered,Available,
+Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-01-FLORDM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-02-DOSTAM000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL495/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-04-CTDGVM000,telemetered,Available,

--- a/GA05MOAS-GL495/GA05MOAS-GL495_R00001_ingest.csv
+++ b/GA05MOAS-GL495/GA05MOAS-GL495_R00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-00-ENG000000,recovered_host,Data not expected
-#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-01-FLORDM000,recovered_host,Data not expected
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-02-DOSTAM000,recovered_host,Data not expected
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-04-CTDGVM000,recovered_host,Data not expected
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-00-ENG000000,recovered_host,Not Expected,Data not expected
+#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-01-FLORDM000,recovered_host,Not Expected,Data not expected
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-02-DOSTAM000,recovered_host,Not Expected,Data not expected
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL495/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-GL495-04-CTDGVM000,recovered_host,Not Expected,Data not expected

--- a/GA05MOAS-GL496/GA05MOAS-GL496_D00001_ingest.csv
+++ b/GA05MOAS-GL496/GA05MOAS-GL496_D00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-00-ENG000000,telemetered
-Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-01-FLORDM000,telemetered
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-02-DOSTAM000,telemetered
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-04-CTDGVM000,telemetered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-00-ENG000000,telemetered,Available,
+Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-01-FLORDM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-02-DOSTAM000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL496/D00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-04-CTDGVM000,telemetered,Available,

--- a/GA05MOAS-GL496/GA05MOAS-GL496_R00001_ingest.csv
+++ b/GA05MOAS-GL496/GA05MOAS-GL496_R00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-00-ENG000000,recovered_host,Glider lost
-#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-01-FLORDM000,recovered_host,Glider lost
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-02-DOSTAM000,recovered_host,Glider lost
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-04-CTDGVM000,recovered_host,Glider lost
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-00-ENG000000,recovered_host,Not Expected,Glider lost
+#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-01-FLORDM000,recovered_host,Not Expected,Glider lost
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-02-DOSTAM000,recovered_host,Not Expected,Glider lost
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL496/R00001/merged-from-glider/ga_496*.mrg,GA05MOAS-GL496-04-CTDGVM000,recovered_host,Not Expected,Glider lost

--- a/GA05MOAS-GL538/GA05MOAS-GL538_D00001_ingest.csv
+++ b/GA05MOAS-GL538/GA05MOAS-GL538_D00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-00-ENG000000,telemetered
-Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-01-FLORDM000,telemetered
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-02-DOSTAM000,telemetered
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-04-CTDGVM000,telemetered
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-00-ENG000000,telemetered,Available,
+Ingest.flord-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-01-FLORDM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-02-DOSTAM000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-GL538/D00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-04-CTDGVM000,telemetered,Available,

--- a/GA05MOAS-GL538/GA05MOAS-GL538_R00001_ingest.csv
+++ b/GA05MOAS-GL538/GA05MOAS-GL538_R00001_ingest.csv
@@ -1,5 +1,5 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-00-ENG000000,recovered_host,No data on server
-#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-01-FLORDM000,recovered_host,No data on server
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-02-DOSTAM000,recovered_host,No data on server
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-04-CTDGVM000,recovered_host,No data on server
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-00-ENG000000,recovered_host,Missing,No data on server
+#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-01-FLORDM000,recovered_host,Missing,No data on server
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-02-DOSTAM000,recovered_host,Missing,No data on server
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-GL538/R00001/merged-from-glider/ga_538*.mrg,GA05MOAS-GL538-04-CTDGVM000,recovered_host,Missing,No data on server

--- a/GA05MOAS-PG562/GA05MOAS-PG562_D00001_ingest.csv
+++ b/GA05MOAS-PG562/GA05MOAS-PG562_D00001_ingest.csv
@@ -1,8 +1,8 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-00-ENG000000,telemetered,
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-01-CTDGVM000,telemetered,
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-02-DOSTAM000,telemetered,
-#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-03-FLORTM000,telemetered,Not configured properly for telemetry
-#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-04-FLORTO000,telemetered,Not configured properly for telemetry. No parser
-Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-05-NUTNRM000,telemetered,
-Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-06-PARADM000,telemetered,
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-00-ENG000000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-01-CTDGVM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-02-DOSTAM000,telemetered,Available,
+#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-03-FLORTM000,telemetered,Not Expected,Not configured properly for telemetry
+#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-04-FLORTO000,telemetered,Not Expected,Not configured properly for telemetry. No parser
+Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-05-NUTNRM000,telemetered,Available,
+Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-06-PARADM000,telemetered,Available,

--- a/GA05MOAS-PG562/GA05MOAS-PG562_R00001_ingest.csv
+++ b/GA05MOAS-PG562/GA05MOAS-PG562_R00001_ingest.csv
@@ -1,8 +1,8 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-00-ENG000000,recovered_host,Glider lost
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-01-CTDGVM000,recovered_host,Glider lost
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-02-DOSTAM000,recovered_host,Glider lost
-#Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-03-FLORTM000,recovered_host,Glider lost
-#Ingest.flort-o-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-04-FLORTO000,recovered_host,Glider lost
-#Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-05-NUTNRM000,recovered_host,Glider lost
-#Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-06-PARADM000,recovered_host,Glider lost
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-00-ENG000000,recovered_host,Not Expected,Glider lost
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-01-CTDGVM000,recovered_host,Not Expected,Glider lost
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-02-DOSTAM000,recovered_host,Not Expected,Glider lost
+#Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-03-FLORTM000,recovered_host,Not Expected,Glider lost
+#Ingest.flort-o-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-04-FLORTO000,recovered_host,Not Expected,Glider lost
+#Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-05-NUTNRM000,recovered_host,Not Expected,Glider lost
+#Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG562/R00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG562-06-PARADM000,recovered_host,Not Expected,Glider lost

--- a/GA05MOAS-PG563/GA05MOAS-PG563_D00001_ingest.csv
+++ b/GA05MOAS-PG563/GA05MOAS-PG563_D00001_ingest.csv
@@ -1,8 +1,8 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-00-ENG000000,telemetered,
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-01-CTDGVM000,telemetered,
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-02-DOSTAM000,telemetered,
-#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-03-FLORTM000,telemetered,Not configured properly for telemetry
-#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-04-FLORTO000,telemetered,Not configured properly for telemetry. No parser
-Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-05-NUTNRM000,telemetered,
-Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-06-PARADM000,telemetered,
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-00-ENG000000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-01-CTDGVM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-02-DOSTAM000,telemetered,Available,
+#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-03-FLORTM000,telemetered,Not Expected,Not configured properly for telemetry
+#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-04-FLORTO000,telemetered,Not Expected,Not configured properly for telemetry. No parser
+Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-05-NUTNRM000,telemetered,Available,
+Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG563-06-PARADM000,telemetered,Available,

--- a/GA05MOAS-PG563/GA05MOAS-PG563_R00001_ingest.csv
+++ b/GA05MOAS-PG563/GA05MOAS-PG563_R00001_ingest.csv
@@ -1,8 +1,8 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-00-ENG000000,recovered_host,
-Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-01-CTDGVM000,recovered_host,
-Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-02-DOSTAM000,recovered_host,
-Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-03-FLORTM000,recovered_host,
-#Ingest.flort-o-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-04-FLORTO000,recovered_host,No parser
-Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-05-NUTNRM000,recovered_host,
-Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-06-PARADM000,recovered_host,
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-00-ENG000000,recovered_host,Available,
+Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-01-CTDGVM000,recovered_host,Available,
+Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-02-DOSTAM000,recovered_host,Available,
+Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-03-FLORTM000,recovered_host,Available,
+#Ingest.flort-o-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-04-FLORTO000,recovered_host,Pending,No parser
+Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-05-NUTNRM000,recovered_host,Available,
+Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/GA05MOAS-PG563/R00001/merged/ga_*.mrg,GA05MOAS-PG563-06-PARADM000,recovered_host,Available,

--- a/GA05MOAS-PG578/GA05MOAS-PG578_D00001_ingest.csv
+++ b/GA05MOAS-PG578/GA05MOAS-PG578_D00001_ingest.csv
@@ -1,8 +1,8 @@
-uframe_route,filename_mask,reference_designator,data_source,
-Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-00-ENG000000,telemetered,
-Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-01-CTDGVM000,telemetered,
-Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-02-DOSTAM000,telemetered,
-Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-03-FLORTM000,telemetered,
-#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-04-FLORTO000,telemetered,No parser
-Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-05-NUTNRM000,telemetered,
-Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-06-PARADM000,telemetered,
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-00-ENG000000,telemetered,Available,
+Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-01-CTDGVM000,telemetered,Available,
+Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-02-DOSTAM000,telemetered,Available,
+Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-03-FLORTM000,telemetered,Available,
+#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-04-FLORTO000,telemetered,Pending,No parser
+Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-05-NUTNRM000,telemetered,Available,
+Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG578/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG578-06-PARADM000,telemetered,Available,

--- a/GA05MOAS-PG580/GA05MOAS-PG580_D00001_ingest.csv
+++ b/GA05MOAS-PG580/GA05MOAS-PG580_D00001_ingest.csv
@@ -1,8 +1,8 @@
-uframe_route,filename_mask,reference_designator,data_source,
-#Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-00-ENG000000,telemetered,No data on server
-#Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-01-CTDGVM000,telemetered,No data on server
-#Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-02-DOSTAM000,telemetered,No data on server
-#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-03-FLORTM000,telemetered,No data on server
-#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-04-FLORTO000,telemetered,No parser
-#Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-05-NUTNRM000,telemetered,No data on server
-#Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-06-PARADM000,telemetered,No data on server
+uframe_route,filename_mask,reference_designator,data_source,status,notes
+#Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-00-ENG000000,telemetered,Missing,No data on server
+#Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-01-CTDGVM000,telemetered,Missing,No data on server
+#Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-02-DOSTAM000,telemetered,Missing,No data on server
+#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-03-FLORTM000,telemetered,Missing,No data on server
+#Ingest.flort-o-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-04-FLORTO000,telemetered,Missing,No parser
+#Ingest.nutnr-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-05-NUTNRM000,telemetered,Missing,No data on server
+#Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/GA05MOAS-PG580/D00001/merged-from-glider/ga_*.mrg,GA05MOAS-PG580-06-PARADM000,telemetered,Missing,No data on server


### PR DESCRIPTION
The files were run through a tool that checks the raw data repos using
the filename_mask column and assign a status to the reference
designator (instrument).
Status Key:

Not Deployed = instrument not deployed
Available = Data delivered to CI
Pending = Data delivered to CI — awaiting Driver/Parser development
Not Expected = Data not to be delivered — Not telemetered, Not
recorded, Lost in transmission, Instrument failed/damaged
Missing = Data to be delivered to CI — awaiting MIO upload to CI
Expected = Data to be delivered to CI — awaiting instrument recovery