### PR TITLE
updated status column

### DIFF
--- a/CP05MOAS-GL340/CP05MOAS-GL340_D00005_ingest.csv
+++ b/CP05MOAS-GL340/CP05MOAS-GL340_D00005_ingest.csv
@@ -1,6 +1,6 @@
 uframe_route,filename_mask,reference_designator,data_source,status,notes
-#Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-00-ENG000000,telemetered,Missing,
-#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-02-FLORTM000,telemetered,Missing,
-#Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-03-CTDGVM000,telemetered,Missing,
-#Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-04-DOSTAM000,telemetered,Missing,
-#Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-05-PARADM000,telemetered,Missing,
+#Ingest.glider-eng-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-00-ENG000000,telemetered,Not Expected,glider leaked after one day
+#Ingest.flort-m-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-02-FLORTM000,telemetered,Not Expected,glider leaked after one day
+#Ingest.ctdgv-m-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-03-CTDGVM000,telemetered,Not Expected,glider leaked after one day
+#Ingest.dosta-abcdjm-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-04-DOSTAM000,telemetered,Not Expected,glider leaked after one day
+#Ingest.parad-m-glider_telemetered,/omc_data/whoi/OMC/CP05MOAS-GL340/D00005/merged-from-glider/cp*.mrg,CP05MOAS-GL340-05-PARADM000,telemetered,Not Expected,glider leaked after one day

--- a/CP05MOAS-GL340/CP05MOAS-GL340_R00005_ingest.csv
+++ b/CP05MOAS-GL340/CP05MOAS-GL340_R00005_ingest.csv
@@ -1,7 +1,7 @@
 uframe_route,filename_mask,reference_designator,data_source,status,notes
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-00-ENG000000,recovered_host,Missing,
-Ingest.adcpa-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/dvl/*.PD0,CP05MOAS-GL340-01-ADCPAM000,recovered_host,Available,
-#Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-02-FLORTM000,recovered_host,Missing,
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-03-CTDGVM000,recovered_host,Missing,
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-04-DOSTAM000,recovered_host,Missing,
-#Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-05-PARADM000,recovered_host,Missing,
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-00-ENG000000,recovered_host,Not Expected,Glider leaked after 1 day
+Ingest.adcpa-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/dvl/*.PD0,CP05MOAS-GL340-01-ADCPAM000,recovered_host,Available,Glider leaked after 1 day
+#Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-02-FLORTM000,recovered_host,Not Expected,Glider leaked after 1 day
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-03-CTDGVM000,recovered_host,Not Expected,Glider leaked after 1 day
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-04-DOSTAM000,recovered_host,Not Expected,Glider leaked after 1 day
+#Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL340/R00005/merged/cp*.mrg,CP05MOAS-GL340-05-PARADM000,recovered_host,Not Expected,Glider leaked after 1 day

--- a/CP05MOAS-GL379/CP05MOAS-GL379_R00004_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_R00004_ingest.csv
@@ -1,7 +1,7 @@
 uframe_route,filename_mask,reference_designator,data_source,status,notes
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-00-ENG000000,recovered_host,Missing,No data on server
-#Ingest.adcpa-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/dvl/*.PD0,CP05MOAS-GL379-01-ADCPAM000,recovered_host,Missing,No data on server
-#Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-02-FLORTM000,recovered_host,Missing,No data on server
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,recovered_host,Missing,No data on server
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,recovered_host,Missing,No data on server
-#Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,recovered_host,Missing,No data on server
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-00-ENG000000,recovered_host,Not Expected glider leacked and recovered with 12 hours,
+#Ingest.adcpa-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/dvl/*.PD0,CP05MOAS-GL379-01-ADCPAM000,recovered_host,Not Expected glider leacked and recovered with 12 hours,
+#Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-02-FLORTM000,recovered_host,Not Expected glider leacked and recovered with 12 hours,
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,recovered_host,Not Expected glider leacked and recovered with 12 hours,
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,recovered_host,Not Expected glider leacked and recovered with 12 hours,
+#Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL379/R00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,recovered_host,Not Expected glider leacked and recovered with 12 hours,

--- a/CP05MOAS-GL388/CP05MOAS-GL388_R00004_ingest.csv
+++ b/CP05MOAS-GL388/CP05MOAS-GL388_R00004_ingest.csv
@@ -1,7 +1,7 @@
 uframe_route,filename_mask,reference_designator,data_source,status,notes
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-00-ENG000000,recovered_host,Missing,No data on server
-#Ingest.adcpa-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/dvl/*.PD0,CP05MOAS-GL388-01-ADCPAM000,recovered_host,Missing,No data on server
-#Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-02-FLORTM000,recovered_host,Missing,No data on server
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-03-CTDGVM000,recovered_host,Missing,No data on server
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-04-DOSTAM000,recovered_host,Missing,No data on server
-#Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-05-PARADM000,recovered_host,Missing,No data on server
+Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-00-ENG000000,recovered_host,Available,
+Ingest.adcpa-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/dvl/*.PD0,CP05MOAS-GL388-01-ADCPAM000,recovered_host,Available,
+Ingest.flort-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-02-FLORTM000,recovered_host,Available,
+Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-03-CTDGVM000,recovered_host,Available,
+Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-04-DOSTAM000,recovered_host,Available,
+Ingest.parad-m-glider_recovered,/omc_data/whoi/OMC/CP05MOAS-GL388/R00004/merged/cp_*.mrg,CP05MOAS-GL388-05-PARADM000,recovered_host,Available,

--- a/GP05MOAS-GL363/GP05MOAS-GL363_R00002_ingest.csv
+++ b/GP05MOAS-GL363/GP05MOAS-GL363_R00002_ingest.csv
@@ -1,5 +1,5 @@
 uframe_route,filename_mask,reference_designator,data_source,status,notes
-#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-00-ENG000000,recovered_host,Missing,no data on server
-#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-01-FLORDM000,recovered_host,Missing,no data on server
-#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-02-DOSTAM000,recovered_host,Missing,no data on server
-#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-04-CTDGVM000,recovered_host,Missing,no data on server
+#Ingest.glider-eng-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-00-ENG000000,recovered_host,Missing,"no data on server, a request was made to the vendor to try to get the data it might not exisit."
+#Ingest.flord-m-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-01-FLORDM000,recovered_host,Missing,"no data on server, a request was made to the vendor to try to get the data it might not exisit."
+#Ingest.dosta-abcdjm-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-02-DOSTAM000,recovered_host,Missing,"no data on server, a request was made to the vendor to try to get the data it might not exisit."
+#Ingest.ctdgv-m-glider_recovered,/omc_data/whoi/OMC/GP05MOAS-GL363/R00002/merged/unit*.mrg,GP05MOAS-GL363-04-CTDGVM000,recovered_host,Missing,"no data on server, a request was made to the vendor to try to get the data it might not exisit."


### PR DESCRIPTION
CP05MOAS-GL388 -  R00004 data were uploaded to CI- data status changed
to Available
GP05MOAS-GL363 -  added text to the note column:  the vendor may have
this data, otherwise it might not exist anymore.
CP05MOAS-GL340 - R00005/D5 recovered and host data are probably not
expected. The glider was deployed, leaked, within a day.
CP05MOAS-GL379 - R00004/D4 recovered and host data are also probably
not expected. The glider was deployed, leaked, and recovered within 12
hours.