### PR TITLE
remover ADCPA row - telemetered data not to be expected

### DIFF
--- a/CP05MOAS-GL379/CP05MOAS-GL379_D00001_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_D00001_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL379-01-ADCPAM000,telemetered,Not Expected,instrument not set to send data via telemetry

--- a/CP05MOAS-GL379/CP05MOAS-GL379_D00002_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_D00002_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL379-01-ADCPAM000,telemetered,Not Expected,instrument not set to send data via telemetry

--- a/CP05MOAS-GL379/CP05MOAS-GL379_D00003_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_D00003_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL379-01-ADCPAM000,telemetered,Not Expected,instrument not set to send data via telemetry

--- a/CP05MOAS-GL379/CP05MOAS-GL379_D00004_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_D00004_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,telemetered,Available,verify dates on files
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,telemetered,Available,verify dates on files
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,telemetered,Available,verify dates on files
-#,,CP05MOAS-GL379-01-ADCPAM000,telemetered,Not Expected,instrument not set to send data via telemetry

--- a/CP05MOAS-GL379/CP05MOAS-GL379_D00005_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_D00005_ingest.csv
@@ -4,4 +4,3 @@ parser,filename_mask,reference_designator,data_source,status,notes
 #mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,telemetered,Not Deployed,not deployed as planned
 #mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,telemetered,Not Deployed,not deployed as planned
 #mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,telemetered,Not Deployed,not deployed as planned
-#,,CP05MOAS-GL379-01-ADCPAM000,telemetered,Not Expected,instrument not set to send data via telemetry

--- a/CP05MOAS-GL380/CP05MOAS-GL380_D00001_ingest.csv
+++ b/CP05MOAS-GL380/CP05MOAS-GL380_D00001_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL380-01-ADCPAM000,telemetered,Not Expected ,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL380/CP05MOAS-GL380_D00002_ingest.csv
+++ b/CP05MOAS-GL380/CP05MOAS-GL380_D00002_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL380-01-ADCPAM000,telemetered,Not Expected ,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL380/CP05MOAS-GL380_D00003_ingest.csv
+++ b/CP05MOAS-GL380/CP05MOAS-GL380_D00003_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL380-01-ADCPAM000,telemetered,Not Expected ,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL380/CP05MOAS-GL380_D00004_ingest.csv
+++ b/CP05MOAS-GL380/CP05MOAS-GL380_D00004_ingest.csv
@@ -1,6 +1,5 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-00-ENG000000,telemetered,Available,
-#,,CP05MOAS-GL380-01-ADCPAM000,telemetered,Not Expected ,Instrument not set to send data via telemetry
 mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-02-FLORTM000,telemetered,Available,
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-04-DOSTAM000,telemetered,Available,

--- a/CP05MOAS-GL380/CP05MOAS-GL380_D00005_ingest.csv
+++ b/CP05MOAS-GL380/CP05MOAS-GL380_D00005_ingest.csv
@@ -1,6 +1,5 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-00-ENG000000,telemetered,Available,
-#,,CP05MOAS-GL380-01-ADCPAM000,telemetered,Not Expected ,Instrument not set to send data via telemetry
 mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-02-FLORTM000,telemetered,Available,
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL380/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL380-04-DOSTAM000,telemetered,Available,

--- a/CP05MOAS-GL387/CP05MOAS-GL387_D00001_ingest.csv
+++ b/CP05MOAS-GL387/CP05MOAS-GL387_D00001_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL387-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL387/CP05MOAS-GL387_D00002_ingest.csv
+++ b/CP05MOAS-GL387/CP05MOAS-GL387_D00002_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL387-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL387/CP05MOAS-GL387_D00003_ingest.csv
+++ b/CP05MOAS-GL387/CP05MOAS-GL387_D00003_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL387-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL387/CP05MOAS-GL387_D00004_ingest.csv
+++ b/CP05MOAS-GL387/CP05MOAS-GL387_D00004_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL387-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL387/CP05MOAS-GL387_D00005_ingest.csv
+++ b/CP05MOAS-GL387/CP05MOAS-GL387_D00005_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL387-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL387/CP05MOAS-GL387_D00006_ingest.csv
+++ b/CP05MOAS-GL387/CP05MOAS-GL387_D00006_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00006/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00006/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL387/D00006/merged-from-glider/cp_*.mrg,CP05MOAS-GL387-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL387-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL388/CP05MOAS-GL388_D00001_ingest.csv
+++ b/CP05MOAS-GL388/CP05MOAS-GL388_D00001_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL388-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL388/CP05MOAS-GL388_D00002_ingest.csv
+++ b/CP05MOAS-GL388/CP05MOAS-GL388_D00002_ingest.csv
@@ -4,4 +4,3 @@ parser,filename_mask,reference_designator,data_source,status,notes
 #mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-03-CTDGVM000,telemetered,Missing,short deployment
 #mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-04-DOSTAM000,telemetered,Missing,short deployment
 #mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-05-PARADM000,telemetered,Missing,short deployment
-#,,CP05MOAS-GL388-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL388/CP05MOAS-GL388_D00003_ingest.csv
+++ b/CP05MOAS-GL388/CP05MOAS-GL388_D00003_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL388-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL388/CP05MOAS-GL388_D00004_ingest.csv
+++ b/CP05MOAS-GL388/CP05MOAS-GL388_D00004_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL388-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL388/CP05MOAS-GL388_D00005_ingest.csv
+++ b/CP05MOAS-GL388/CP05MOAS-GL388_D00005_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL388/D00005/merged-from-glider/cp_*.mrg,CP05MOAS-GL388-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL388-01-ADCPAM000,telemetered,Not Expected,Instrument not set to send data via telemetry

--- a/CP05MOAS-GL389/CP05MOAS-GL389_D00001_ingest.csv
+++ b/CP05MOAS-GL389/CP05MOAS-GL389_D00001_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00001/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL389-01-ADCPAM000,telemetered,Not Expected, Instrument not set to send data via telemetry

--- a/CP05MOAS-GL389/CP05MOAS-GL389_D00002_ingest.csv
+++ b/CP05MOAS-GL389/CP05MOAS-GL389_D00002_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00002/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL389-01-ADCPAM000,telemetered,Not Expected, Instrument not set to send data via telemetry

--- a/CP05MOAS-GL389/CP05MOAS-GL389_D00003_ingest.csv
+++ b/CP05MOAS-GL389/CP05MOAS-GL389_D00003_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00003/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL389-01-ADCPAM000,telemetered,Not Expected, Instrument not set to send data via telemetry

--- a/CP05MOAS-GL389/CP05MOAS-GL389_D00004_ingest.csv
+++ b/CP05MOAS-GL389/CP05MOAS-GL389_D00004_ingest.csv
@@ -4,4 +4,3 @@ mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/wh
 mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-03-CTDGVM000,telemetered,Available,
 mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-04-DOSTAM000,telemetered,Available,
 mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00004/merged-from-glider/cp_*.mrg,CP05MOAS-GL389-05-PARADM000,telemetered,Available,
-#,,CP05MOAS-GL389-01-ADCPAM000,telemetered,Not Expected, Instrument not set to send data via telemetry


### PR DESCRIPTION
Gliders with ADCPA data that are not expected via telemetry are:
CP05MOAS-GL379
CP05MOAS-GL380
CP05MOAS-GL387
CP05MOAS-GL388
CP05MOAS-GL389