### PR TITLE
updated for Pioneer 10 data ingest

### DIFF
--- a/CP03ISSM/CP03ISSM_D00008_ingest.csv
+++ b/CP03ISSM/CP03ISSM_D00008_ingest.csv
@@ -5,7 +5,7 @@ mi.dataset.driver.adcpt_acfgm.dcl.pd8.adcpt_acfgm_dcl_pd8_telemetered_driver,/om
 mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl36/presf/*.presf.log,CP03ISSM-MFD35-02-PRESFB000,telemetered,Available,
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl36/velpt2/*.velpt2.log,CP03ISSM-MFD35-04-VELPTA000,telemetered,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl36/pco2w/*.pco2w.log,CP03ISSM-MFD35-05-PCO2WB000,telemetered,Available,
-mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl36/phsen2/*.phsen2.log,CP03ISSM-MFD35-06-PHSEND000,telemetered,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl36/phsen2/*.phsen2.log,CP03ISSM-MFD35-06-PHSEND000,telemetered,Available,parser error
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl37/syslog/*.syslog.log,CP03ISSM-MFD37-00-DCLENG000,telemetered,Available,
 #mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl37/optaa2/*.optaa2.log,CP03ISSM-MFD37-01-OPTAAD000,telemetered,Not Deployed,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl37/ctdbp2/*.ctdbp2.log,CP03ISSM-MFD37-03-CTDBPD000,telemetered,Available,
@@ -14,8 +14,8 @@ mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/
 mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/cpm2/syslog/cpm_status*.txt,CP03ISSM-RIC21-00-CPMENG000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl26/syslog/*.syslog.log,CP03ISSM-RID26-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl26/velpt1/*.velpt1.log,CP03ISSM-RID26-04-VELPTA000,telemetered,Available,
-mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl26/phsen1/*.phsen1.log,CP03ISSM-RID26-06-PHSEND000,telemetered,Available,
-mi.dataset.driver.nutnr_b.dcl_full.nutnr_b_dcl_full_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl26/nutnr/*.nutnr.log,CP03ISSM-RID26-07-NUTNRB000,telemetered,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl26/phsen1/*.phsen1.log,CP03ISSM-RID26-06-PHSEND000,telemetered,Available,parser error
+#mi.dataset.driver.nutnr_b.dcl_full.nutnr_b_dcl_full_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl26/nutnr/*.nutnr.log,CP03ISSM-RID26-07-NUTNRB000,telemetered,Pending,parser not ready
 mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl26/spkir/*.spkir.log,CP03ISSM-RID26-08-SPKIRB000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl27/syslog/*.syslog.log,CP03ISSM-RID27-00-DCLENG000,telemetered,Available,
 #mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl27/optaa1/*.optaa1.log,CP03ISSM-RID27-01-OPTAAD000,telemetered,Not Deployed,
@@ -24,7 +24,7 @@ mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/who
 mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl27/dosta1/*.dosta1.log,CP03ISSM-RID27-04-DOSTAD000,telemetered,Available,
 mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/irid2shore/cpm_status*.txt,CP03ISSM-SBC11-00-CPMENG000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl11/syslog/*.syslog.log,CP03ISSM-SBD11-00-DCLENG000,telemetered,Available,
-mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl11/mopak/*.mopak.log,CP03ISSM-SBD11-01-MOPAK0000,telemetered,Available,
+#mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl11/mopak/*.mopak.log,CP03ISSM-SBD11-01-MOPAK0000,telemetered,Pending,do not ingest until farther notice.
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl11/hyd1/*hyd1.log,CP03ISSM-SBD11-02-HYDGN0000,telemetered,Available,
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl11/metbk/*.metbk*.log,CP03ISSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00008/cg_data/dcl12/syslog/*.syslog.log,CP03ISSM-SBD12-00-DCLENG000,telemetered,Available,


### PR DESCRIPTION
MOPAK and NUTNR cannot be ingested at this time:

MOPAK: system not ready to handle data ingest from this type of instrument.

NUTNR: the parser is not ready for data ingestion.