### PR TITLE
updated file for Pioneer 10 data ingest

### DIFF
--- a/CP04OSSM/CP04OSSM_D00008_ingest.csv
+++ b/CP04OSSM/CP04OSSM_D00008_ingest.csv
@@ -5,7 +5,7 @@ mi.dataset.driver.adcpt_acfgm.dcl.pd8.adcpt_acfgm_dcl_pd8_telemetered_driver,/om
 mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl36/presf/*.presf.log,CP04OSSM-MFD35-02-PRESFC000,telemetered,Available,
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl36/velpt2/*.velpt*.log,CP04OSSM-MFD35-04-VELPTB000,telemetered,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl36/pco2w/*.pco2w.log,CP04OSSM-MFD35-05-PCO2WB000,telemetered,Available,
-mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl36/phsen2/*.phsen*.log,CP04OSSM-MFD35-06-PHSEND000,telemetered,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl36/phsen2/*.phsen*.log,CP04OSSM-MFD35-06-PHSEND000,telemetered,Available,parser error on local machine
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl37/syslog/*.syslog.log,CP04OSSM-MFD37-00-DCLENG000,telemetered,Available,
 #mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl37/optaa2/*.optaa*.log,CP04OSSM-MFD37-01-OPTAAD000,telemetered,Not Deployed,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CP04OSSM-MFD37-03-CTDBPE000,telemetered,Available,
@@ -14,8 +14,8 @@ mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/
 mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/cpm2/syslog/cpm_status*.txt,CP04OSSM-RIC21-00-CPMENG000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl26/syslog/*.syslog.log,CP04OSSM-RID26-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl26/velpt1/*.velpt*.log,CP04OSSM-RID26-04-VELPTA000,telemetered,Available,
-mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl26/phsen1/*.phsen*.log,CP04OSSM-RID26-06-PHSEND000,telemetered,Available,
-mi.dataset.driver.nutnr_b.dcl_full.nutnr_b_dcl_full_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl26/nutnr/*.nutnr.log,CP04OSSM-RID26-07-NUTNRB000,telemetered,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl26/phsen1/*.phsen*.log,CP04OSSM-RID26-06-PHSEND000,telemetered,Available,parser error on local machine
+#mi.dataset.driver.nutnr_b.dcl_full.nutnr_b_dcl_full_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl26/nutnr/*.nutnr.log,CP04OSSM-RID26-07-NUTNRB000,telemetered,Pending,New parser in not ready
 mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl26/spkir/*.spkir.log,CP04OSSM-RID26-08-SPKIRB000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl27/syslog/*.syslog.log,CP04OSSM-RID27-00-DCLENG000,telemetered,Available,
 #mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl27/optaa1/*.optaa*.log,CP04OSSM-RID27-01-OPTAAD000,telemetered,Not Deployed,
@@ -24,7 +24,7 @@ mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/who
 mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl27/dosta1/*.dosta*.log,CP04OSSM-RID27-04-DOSTAD000,telemetered,Available,
 mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/irid2shore/cpm_status*.txt,CP04OSSM-SBC11-00-CPMENG000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl11/syslog/*.syslog.log,CP04OSSM-SBD11-00-DCLENG000,telemetered,Available,
-mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl11/mopak/*.mopak.log,CP04OSSM-SBD11-01-MOPAK0000,telemetered,Available, 
+#mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl11/mopak/*.mopak.log,CP04OSSM-SBD11-01-MOPAK0000,telemetered,Pending,System not ready to handle ingesting data from this instrument
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl11/hyd*/*hyd*.log,CP04OSSM-SBD11-02-HYDGN0000,telemetered,Available,
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl11/metbk/*.metbk.log,CP04OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00008/cg_data/dcl12/syslog/*.syslog.log,CP04OSSM-SBD12-00-DCLENG000,telemetered,Available,


### PR DESCRIPTION
Notes:
CP04OSSM-MFD35-06-PHSEND000 & CP04OSSM-RID26-06-PHSEND000 the parser
errors seem to occur only on my machine since data ingest is in
progress regardless of the error.
CP04OSSM-RID26-07-NUTNRB000 parser for the new NUTNR instrument model
is not ready to use with ingestion.
CP04OSSM-SBD11-01-MOPAK0000 ingestion postponed until further notice.
A fix is needed for the system to handle the MOPAK ingestion.