### PR TITLE
commented out ADCP row

### DIFF
--- a/CP05MOAS-A6263/CP05MOAS-A6263_R00002_ingest.csv
+++ b/CP05MOAS-A6263/CP05MOAS-A6263_R00002_ingest.csv
@@ -4,5 +4,5 @@ mi.dataset.driver.flort_kn.auv.flort_kn_auv_recovered_driver,/omc_data/whoi/OMC/
 mi.dataset.driver.dosta_ln.auv.dosta_ln_auv_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6263/R00002/*.csv,CP05MOAS-A6263-02-DOSTAN000,recovered_host,Available,
 mi.dataset.driver.ctdav_n.auv.ctdav_n_auv_driver,/omc_data/whoi/OMC/CP05MOAS-A6263/R00002/*.csv,CP05MOAS-A6263-03-CTDAVN000,recovered_host,Available,
 mi.dataset.driver.nutnr_n.nutnr_n_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6263/R00002/*.SUN,CP05MOAS-A6263-04-NUTNRN000,recovered_host,Available,
-mi.dataset.driver.adcpa_n.adcpa_n_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6263/R00002/*.ADC,CP05MOAS-A6263-05-ADCPAN000,recovered_host,Available,
+#mi.dataset.driver.adcpa_n.adcpa_n_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6263/R00002/*.ADC,CP05MOAS-A6263-05-ADCPAN000,recovered_host,Available,ingest when SS# is in asset management 
 mi.dataset.driver.parad_n.auv.parad_n_auv_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6263/R00002/*.csv,CP05MOAS-A6263-06-PARADN000,recovered_host,Available,

--- a/CP05MOAS-A6264/CP05MOAS-A6264_R00002_ingest.csv
+++ b/CP05MOAS-A6264/CP05MOAS-A6264_R00002_ingest.csv
@@ -4,5 +4,5 @@ mi.dataset.driver.flort_kn.auv.flort_kn_auv_recovered_driver,/omc_data/whoi/OMC/
 mi.dataset.driver.dosta_ln.auv.dosta_ln_auv_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6264/R00002/*.csv,CP05MOAS-A6264-02-DOSTAN000,recovered_host,Available,
 mi.dataset.driver.ctdav_n.auv.ctdav_n_auv_driver,/omc_data/whoi/OMC/CP05MOAS-A6264/R00002/*.csv,CP05MOAS-A6264-03-CTDAVN000,recovered_host,Available,
 mi.dataset.driver.nutnr_n.nutnr_n_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6264/R00002/*.SUN,CP05MOAS-A6264-04-NUTNRN000,recovered_host,Available,
-mi.dataset.driver.adcpa_n.adcpa_n_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6264/R00002/*.ADC,CP05MOAS-A6264-05-ADCPAN000,recovered_host,Available,
+#mi.dataset.driver.adcpa_n.adcpa_n_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6264/R00002/*.ADC,CP05MOAS-A6264-05-ADCPAN000,recovered_host,Available,ingest when SS# is provided in asset management
 mi.dataset.driver.parad_n.auv.parad_n_auv_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-A6264/R00002/*.csv,CP05MOAS-A6264-06-PARADN000,recovered_host,Available,


### PR DESCRIPTION
ADCP instrument is still missing a SN# in asset management so the data
cannot be ingested. It is noted here as a reference to remember to
ingest when the SN# is provided.