### PR TITLE
Endurance 10 Fall 2018 Leg 3 Updates

### DIFF
--- a/CE01ISSM/CE01ISSM_D00010_ingest.csv
+++ b/CE01ISSM/CE01ISSM_D00010_ingest.csv
@@ -1,30 +1,30 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-#mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/cpm3/syslog/cpm_status.txt,CE01ISSM-MFC31-00-CPMENG000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/syslog/*.syslog.log,CE01ISSM-MFD35-00-DCLENG000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/vel3d/*.vel3d.log,CE01ISSM-MFD35-01-VEL3DD000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/presf/*.presf.log,CE01ISSM-MFD35-02-PRESFA000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/adcpt/*.adcpt.log,CE01ISSM-MFD35-04-ADCPTM000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/pco2w*/*.pco2w*.log,CE01ISSM-MFD35-05-PCO2WB000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/phsen*/*.phsen*.log,CE01ISSM-MFD35-06-PHSEND000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/syslog/*.syslog.log,CE01ISSM-MFD37-00-DCLENG000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/optaa*/*.optaa*.log,CE01ISSM-MFD37-01-OPTAAD000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE01ISSM-MFD37-03-CTDBPC000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE01ISSM-MFD37-03-DOSTAD000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/syslog/*.syslog.log,CE01ISSM-RID16-00-DCLENG000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/optaa*/*.optaa*.log,CE01ISSM-RID16-01-OPTAAD000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/flort/*.flort.log,CE01ISSM-RID16-02-FLORTD000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/ctdbp*/*.ctdbp*.log,CE01ISSM-RID16-03-CTDBPC000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/ctdbp*/*.ctdbp*.log,CE01ISSM-RID16-03-DOSTAD000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/velpt*/*.velpt*.log,CE01ISSM-RID16-04-VELPTA000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/pco2w*/*.pco2w*.log,CE01ISSM-RID16-05-PCO2WB000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/phsen*/*.phsen*.log,CE01ISSM-RID16-06-PHSEND000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/nutnr/*.nutnr.log,CE01ISSM-RID16-07-NUTNRB000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/spkir/*.spkir.log,CE01ISSM-RID16-08-SPKIRB000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/irid2shore/cpm_status*.txt,CE01ISSM-SBC11-00-CPMENG000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/syslog/*.syslog.log,CE01ISSM-SBD17-00-DCLENG000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE01ISSM-SBD17-06-CTDBPC000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE01ISSM-SBD17-06-FLORTD000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/mopak/*.mopak.log,CE01ISSM-SBD17-01-MOPAK0000,telemetered,Expected,Future deployment 
-#mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/velpt*/*.velpt*.log,CE01ISSM-SBD17-04-VELPTA000,telemetered,Expected,Future deployment 
-#,/omc_data/whoi/OMC/CE01ISSM/D00010/,CE01ISSM-MFD37-06-CAMDSA000,telemetered,Expected,Future deployment 
+mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/cpm3/syslog/cpm_status.txt,CE01ISSM-MFC31-00-CPMENG000,telemetered,Available, 
+mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/syslog/*.syslog.log,CE01ISSM-MFD35-00-DCLENG000,telemetered,Available, 
+mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/vel3d/*.vel3d.log,CE01ISSM-MFD35-01-VEL3DD000,telemetered,Available, 
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/presf/*.presf.log,CE01ISSM-MFD35-02-PRESFA000,telemetered,Available, 
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/adcpt/*.adcpt.log,CE01ISSM-MFD35-04-ADCPTM000,telemetered,Available, 
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/pco2w*/*.pco2w*.log,CE01ISSM-MFD35-05-PCO2WB000,telemetered,Available, 
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl36/phsen*/*.phsen*.log,CE01ISSM-MFD35-06-PHSEND000,telemetered,Available, 
+#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/syslog/*.syslog.log,CE01ISSM-MFD37-00-DCLENG000,telemetered,Expected,Currently experiencing issues 
+#mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/optaa*/*.optaa*.log,CE01ISSM-MFD37-01-OPTAAD000,telemetered,Expected,Currently experiencing issues 
+#mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE01ISSM-MFD37-03-CTDBPC000,telemetered,Expected,Currently experiencing issues 
+#mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE01ISSM-MFD37-03-DOSTAD000,telemetered,Expected,Currently experiencing issues 
+#mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,telemetered,Expected,Currently experiencing issues 
+mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/syslog/*.syslog.log,CE01ISSM-RID16-00-DCLENG000,telemetered,Available, 
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/optaa*/*.optaa*.log,CE01ISSM-RID16-01-OPTAAD000,telemetered,Available, 
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/flort/*.flort.log,CE01ISSM-RID16-02-FLORTD000,telemetered,Available, 
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/ctdbp*/*.ctdbp*.log,CE01ISSM-RID16-03-CTDBPC000,telemetered,Available, 
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/ctdbp*/*.ctdbp*.log,CE01ISSM-RID16-03-DOSTAD000,telemetered,Available, 
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/velpt*/*.velpt*.log,CE01ISSM-RID16-04-VELPTA000,telemetered,Available, 
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/pco2w*/*.pco2w*.log,CE01ISSM-RID16-05-PCO2WB000,telemetered,Available, 
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/phsen*/*.phsen*.log,CE01ISSM-RID16-06-PHSEND000,telemetered,Available, 
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/nutnr/*.nutnr.log,CE01ISSM-RID16-07-NUTNRB000,telemetered,Available, 
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl16/spkir/*.spkir.log,CE01ISSM-RID16-08-SPKIRB000,telemetered,Available, 
+mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/irid2shore/cpm_status*.txt,CE01ISSM-SBC11-00-CPMENG000,telemetered,Available, 
+mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/syslog/*.syslog.log,CE01ISSM-SBD17-00-DCLENG000,telemetered,Available, 
+#mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE01ISSM-SBD17-06-CTDBPC000,telemetered,Available, 
+#mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE01ISSM-SBD17-06-FLORTD000,telemetered,Available, 
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/mopak/*.mopak.log,CE01ISSM-SBD17-01-MOPAK0000,telemetered,Available, 
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00010/cg_data/dcl17/velpt*/*.velpt*.log,CE01ISSM-SBD17-04-VELPTA000,telemetered,Available, 
+#,/omc_data/whoi/OMC/CE01ISSM/D00010/,CE01ISSM-MFD37-06-CAMDSA000,telemetered,Not Expected,Instrument was not deployed 

--- a/CE04OSSM/CE04OSSM_D00007_ingest.csv
+++ b/CE04OSSM/CE04OSSM_D00007_ingest.csv
@@ -1,23 +1,23 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-#mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/cpm2/syslog/cpm_status.txt,CE04OSSM-RIC21-00-CPMENG000,telemetered,Expected,Future deployment
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/syslog/*.syslog.log,CE04OSSM-RID26-00-DCLENG000,telemetered,Expected,Future deployment
-#mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/adcpt/*.adcpt.log,CE04OSSM-RID26-01-ADCPTC000,telemetered,Expected,Future deployment
-#mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/velpt2/*.velpt*.log,CE04OSSM-RID26-04-VELPTA000,telemetered,Expected,Future deployment
-#mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/phsen/*.phsen.log,CE04OSSM-RID26-06-PHSEND000,telemetered,Expected,Future deployment
-#mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/nutnr/*.nutnr.log,CE04OSSM-RID26-07-NUTNRB000,telemetered,Expected,Future deployment
-#mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/spkir/*.spkir.log,CE04OSSM-RID26-08-SPKIRB000,telemetered,Expected,Future deployment
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/syslog/*.syslog.log,CE04OSSM-RID27-00-DCLENG000,telemetered,Expected,Future deployment
-#mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/optaa/*.optaa.log,CE04OSSM-RID27-01-OPTAAD000,telemetered,Expected,Future deployment
-#mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/flort/*.flort.log,CE04OSSM-RID27-02-FLORTD000,telemetered,Expected,Future deployment
-#mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/ctdbp/*.ctdbp.log,CE04OSSM-RID27-03-CTDBPC000,telemetered,Expected,Future deployment
-#mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/dosta/*.dosta.log,CE04OSSM-RID27-04-DOSTAD000,telemetered,Expected,Future deployment
-#mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/irid2shore/cpm_status*.txt,CE04OSSM-SBC11-00-CPMENG000,telemetered,Expected,Future deployment
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/syslog/*.syslog.log,CE04OSSM-SBD11-00-DCLENG000,telemetered,Expected,Future deployment
-#mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/mopak/*.mopak.log,CE04OSSM-SBD11-01-MOPAK0000,telemetered,Expected,Future deployment
-#mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/hyd1/*.hyd*.log,CE04OSSM-SBD11-02-HYDGN0000,telemetered,Expected,Future deployment
-#mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/velpt1/*.velpt*.log,CE04OSSM-SBD11-04-VELPTA000,telemetered,Expected,Future deployment
-#mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,telemetered,Expected,Future deployment
-#mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,telemetered,Expected,Future deployment
-#mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/hyd2/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,telemetered,Expected,Future deployment
-#mi.dataset.driver.pco2a_a.dcl.pco2a_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Expected,Future deployment
-#mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,telemetered,Expected,Future deployment
+mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/cpm2/syslog/cpm_status.txt,CE04OSSM-RIC21-00-CPMENG000,telemetered,Available,
+mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/syslog/*.syslog.log,CE04OSSM-RID26-00-DCLENG000,telemetered,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/adcpt/*.adcpt.log,CE04OSSM-RID26-01-ADCPTC000,telemetered,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/velpt2/*.velpt*.log,CE04OSSM-RID26-04-VELPTA000,telemetered,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/phsen/*.phsen.log,CE04OSSM-RID26-06-PHSEND000,telemetered,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/nutnr/*.nutnr.log,CE04OSSM-RID26-07-NUTNRB000,telemetered,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl26/spkir/*.spkir.log,CE04OSSM-RID26-08-SPKIRB000,telemetered,Available,
+mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/syslog/*.syslog.log,CE04OSSM-RID27-00-DCLENG000,telemetered,Available,
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/optaa/*.optaa.log,CE04OSSM-RID27-01-OPTAAD000,telemetered,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/flort/*.flort.log,CE04OSSM-RID27-02-FLORTD000,telemetered,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/ctdbp/*.ctdbp.log,CE04OSSM-RID27-03-CTDBPC000,telemetered,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl27/dosta/*.dosta.log,CE04OSSM-RID27-04-DOSTAD000,telemetered,Available,
+mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/irid2shore/cpm_status*.txt,CE04OSSM-SBC11-00-CPMENG000,telemetered,Available,
+mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/syslog/*.syslog.log,CE04OSSM-SBD11-00-DCLENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/mopak/*.mopak.log,CE04OSSM-SBD11-01-MOPAK0000,telemetered,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/hyd1/*.hyd*.log,CE04OSSM-SBD11-02-HYDGN0000,telemetered,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/velpt1/*.velpt*.log,CE04OSSM-SBD11-04-VELPTA000,telemetered,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,telemetered,Available,
+mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,telemetered,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/hyd2/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,telemetered,Available,
+mi.dataset.driver.pco2a_a.dcl.pco2a_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00007/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE06ISSM/CE06ISSM_D00009_ingest.csv
+++ b/CE06ISSM/CE06ISSM_D00009_ingest.csv
@@ -23,8 +23,8 @@ mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_dat
 mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl16/spkir/*.spkir.log,CE06ISSM-RID16-08-SPKIRB000,telemetered,Available,
 mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/irid2shore/cpm_status*.txt,CE06ISSM-SBC11-00-CPMENG000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl17/syslog/*.syslog.log,CE06ISSM-SBD17-00-DCLENG000,telemetered,Available,
-mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE06ISSM-SBD17-06-CTDBPC000,telemetered,Available,
-mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE06ISSM-SBD17-06-FLORTD000,telemetered,Available,
+#mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE06ISSM-SBD17-06-CTDBPC000,telemetered,Available,
+#mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE06ISSM-SBD17-06-FLORTD000,telemetered,Available,
 mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl17/mopak/*.mopak.log,CE06ISSM-SBD17-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00009/cg_data/dcl17/velpt1/*.velpt*.log,CE06ISSM-SBD17-04-VELPTA000,telemetered,Available,
 #,/omc_data/whoi/OMC/CE06ISSM/D00009/,CE06ISSM-MFD37-06-CAMDSA000,telemetered,Not Deployed,"Due to CAMDS firmware failure, instrument not deployed"


### PR DESCRIPTION
Updates the ingest sheets for Leg 3 (CE01ISSM and CE04OSSM). Couple issues to consider. Driver for ingesting the CTDBP3 data (CTDBP+FLORT) is probably incorrect, so I commented those ingest statements out (for CE06ISSM as well). Also, DCL37 is non-responsive on CE01ISSM. Has been dark since we deployed. Those ingests are also commented out. I'll need to determine what's going on there when I get back.

@leilabbb @desiderr @crisien Please review and merge.