### PR TITLE
CE05MOAS-GL327 Deployment 00007

### DIFF
--- a/CE05MOAS-GL327/CE05MOAS-GL327_R00007_ingest.csv
+++ b/CE05MOAS-GL327/CE05MOAS-GL327_R00007_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/R00007/merged/ce_*.mrg,CE05MOAS-GL327-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/R00007/merged/ce_*.mrg,CE05MOAS-GL327-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/R00007/merged/ce_*.mrg,CE05MOAS-GL327-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/R00007/dvl/*.pd0,CE05MOAS-GL327-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/R00007/merged/ce_*.mrg,CE05MOAS-GL327-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/R00007/merged/ce_*.mrg,CE05MOAS-GL327-05-CTDGVM000,recovered_host,Available,


### PR DESCRIPTION
Creates an ingest sheet for the recovered data from CE05MOAS-GL327, deployment 7.

@s-pearce please review and confirm ingest sheets for Endurance gliders are current.