### PR TITLE
 Pioneer 11b Gliders

### DIFF
--- a/CP05MOAS-GL340/CP05MOAS-GL340_D00008_ingest.csv
+++ b/CP05MOAS-GL340/CP05MOAS-GL340_D00008_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/D00008/merged-from-glider/cp_340*.mrg,CP05MOAS-GL340-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/D00008/merged-from-glider/cp_340*.mrg,CP05MOAS-GL340-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/D00008/merged-from-glider/cp_340*.mrg,CP05MOAS-GL340-03-CTDGVM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/D00008/merged-from-glider/cp_340*.mrg,CP05MOAS-GL340-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/D00008/merged-from-glider/cp_340*.mrg,CP05MOAS-GL340-05-PARADM000,telemetered,Available,

--- a/CP05MOAS-GL379/CP05MOAS-GL379_D00006_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_D00006_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00006/merged-from-glider/cp_379*.mrg,CP05MOAS-GL379-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00006/merged-from-glider/cp_379*.mrg,CP05MOAS-GL379-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00006/merged-from-glider/cp_379*.mrg,CP05MOAS-GL379-03-CTDGVM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00006/merged-from-glider/cp_379*.mrg,CP05MOAS-GL379-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/D00006/merged-from-glider/cp_379*.mrg,CP05MOAS-GL379-05-PARADM000,telemetered,Available,

--- a/CP05MOAS-GL389/CP05MOAS-GL389_D00006_ingest.csv
+++ b/CP05MOAS-GL389/CP05MOAS-GL389_D00006_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00006/merged-from-glider/cp_389*.mrg,CP05MOAS-GL389-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00006/merged-from-glider/cp_389*.mrg,CP05MOAS-GL389-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00006/merged-from-glider/cp_389*.mrg,CP05MOAS-GL389-03-CTDGVM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00006/merged-from-glider/cp_389*.mrg,CP05MOAS-GL389-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-GL389/D00006/merged-from-glider/cp_389*.mrg,CP05MOAS-GL389-05-PARADM000,telemetered,Available,


### PR DESCRIPTION
Created ingestion csvs for the gliders deployed on the P11b turn:
-340 D8
-379 D6
-389 D6
