### PR TITLE
Updating ingest sheets for the conclusion of Endurance 12

### DIFF
--- a/CE05MOAS-GL311/CE05MOAS-GL311_D00009_ingest.csv
+++ b/CE05MOAS-GL311/CE05MOAS-GL311_D00009_ingest.csv
@@ -1,6 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-00-ENG000000,telemetered,Expected,
-mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-01-PARADM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-02-FLORTM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-04-DOSTAM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-05-CTDGVM000,telemetered,Expected,
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL312/CE05MOAS-GL312_D00009_ingest.csv
+++ b/CE05MOAS-GL312/CE05MOAS-GL312_D00009_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL319/CE05MOAS-GL319_R00009_ingest.csv
+++ b/CE05MOAS-GL319/CE05MOAS-GL319_R00009_ingest.csv
@@ -1,7 +1,7 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-00-ENG000000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-01-PARADM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-02-FLORTM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/dvl/*.pd0,CE05MOAS-GL319-03-ADCPAM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-04-DOSTAM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-05-CTDGVM000,recovered_host,Expected,
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/dvl/*.pd0,CE05MOAS-GL319-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00009/merged/ce_*.mrg,CE05MOAS-GL319-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL320/CE05MOAS-GL320_D00005_ingest.csv
+++ b/CE05MOAS-GL320/CE05MOAS-GL320_D00005_ingest.csv
@@ -1,6 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-00-ENG000000,telemetered,Expected,
-mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-01-PARADM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-02-FLORTM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-04-DOSTAM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-05-CTDGVM000,telemetered,Expected,
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL320/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-GL320-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL327/CE05MOAS-GL327_D00009_ingest.csv
+++ b/CE05MOAS-GL327/CE05MOAS-GL327_D00009_ingest.csv
@@ -1,6 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-00-ENG000000,telemetered,Expected,
-mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-01-PARADM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-02-FLORTM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-04-DOSTAM000,telemetered,Expected,
-mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-05-CTDGVM000,telemetered,Expected,
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL327/D00009/merged-from-glider/ce_*.mrg,CE05MOAS-GL327-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL384/CE05MOAS-GL384_R00007_ingest.csv
+++ b/CE05MOAS-GL384/CE05MOAS-GL384_R00007_ingest.csv
@@ -1,7 +1,7 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-00-ENG000000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-01-PARADM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-02-FLORTM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/dvl/*.pd0,CE05MOAS-GL384-03-ADCPAM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-04-DOSTAM000,recovered_host,Expected,
-mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-05-CTDGVM000,recovered_host,Expected,
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/dvl/*.pd0,CE05MOAS-GL384-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL384/R00007/merged/ce_*.full.mrg,CE05MOAS-GL384-05-CTDGVM000,recovered_host,Available,


### PR DESCRIPTION
Final, updated ingest sheets for the Endurance 12 cruise. CSPPs were deployed, but those systems are not telemetering data, so no ingests sheets at this time.