### PR TITLE
Recovered CE02SHSM-00020 data

### DIFF
--- a/CE02SHSM/CE02SHSM_R00020_ingest.csv
+++ b/CE02SHSM/CE02SHSM_R00020_ingest.csv
@@ -1,0 +1,32 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/cpm2/syslog/cpm_status.txt,CE02SHSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl26/syslog/*.syslog.log,CE02SHSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl26/adcpt/*.adcpt.log,CE02SHSM-RID26-01-ADCPTA000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl26/ADCPT*/*adcpt*.000,CE02SHSM-RID26-01-ADCPTA000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl26/velpt*/*.velpt*.log,CE02SHSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl26/VELPT*/*velpt*.aqd,CE02SHSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_gh.phsen_gh_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl26/phsen/*.phsen.log,CE02SHSM-RID26-06-PHSENG000,recovered_host,Available,
+#,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE02SHSM-RID26-06-PHSENG000,recovered_inst,Pending,Parser not yet implemented
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl26/nutnr/*.nutnr.log,CE02SHSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE02SHSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl26/spkir/*.spkir.log,CE02SHSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl27/syslog/*.syslog.log,CE02SHSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl27/optaa/*.optaa.log,CE02SHSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl27/flort/*.flort.log,CE02SHSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl27/ctdbp/*.ctdbp.log,CE02SHSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl27/CTDBP*/*ctdbp*.hex,CE02SHSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl27/dosta/*.dosta.log,CE02SHSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/irid2shore/cpm_status*.txt,CE02SHSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl11/syslog/*.syslog.log,CE02SHSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl11/mopak/*.mopak.log,CE02SHSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl11/hyd*/*.hyd*.log,CE02SHSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl11/velpt*/*.velpt*.log,CE02SHSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl11/VELPT*/*velpt*.aqd,CE02SHSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA000,recovered_host,Available,
+mi.dataset.driver.metbk_ct.metbk_ct_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl11/METBK-CT*/*.hex,CE02SHSM-SBD11-06-METBKA001,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl12/syslog/*.syslog.log,CE02SHSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl12/hyd*/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,recovered_host,Available,
+mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,recovered_host,Available,
+# mi.dataset.driver.fdchp_a.fdchp_a_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00020/instrmts/dcl12/FDCHP*/*fdchp*/*/fdchp*.dat,CE02SHSM-SBD12-08-FDCHPA000,recovered_inst,Pending,Incorrectly implemented processing code


### PR DESCRIPTION
Drops the recovered metbk-ct to dcl ingest (that was always a mistake and will be corrected going forward). Otherwise, standard ingest for CE02.